### PR TITLE
[density] remove wrong length check

### DIFF
--- a/src/density.jl
+++ b/src/density.jl
@@ -139,7 +139,7 @@ Output is stored in
 
 Array size requirements:
 
-    size(params, 1) == length(r)
+    size(params, 2) == length(r)
 
 Note: `density_logval!` must not be called with out-of-bounds parameter
 vectors (see `param_bounds`). The result of `density_logval!` for parameter
@@ -158,7 +158,7 @@ function density_logval!(
     params::AbstractMatrix{<:Real},
     exec_context::ExecContext = ExecContext()
 )
-    !(size(r, 1) == nparams(density)) && throw(ArgumentError("Invalid length of parameter vector"))
+
     !(size(params, 1) == nparams(density)) && throw(ArgumentError("Invalid length of parameter vector"))
     !(indices(params, 2) == indices(r, 1)) && throw(ArgumentError("Number of parameter vectors doesn't match length of result vector"))
     unsafe_density_logval!(r, density, params, exec_context)
@@ -179,9 +179,8 @@ doc"""
 
 Unsafe variant of `density_logval!`, implementations may rely on
 
-* `size(r, 1) == nparams(density)`
 * `size(params, 1) == nparams(density)`
-* `indices(params, 2) == indices(r, 1)`
+* `size(params, 2) == length(r)`
 
 The caller *must* ensure that these conditions are met!
 """

--- a/test/density.jl
+++ b/test/density.jl
@@ -22,7 +22,7 @@ BAT.sampler(td::test_density) = BAT.sampler(MvNormal(ones(3), PDMat(eye(3))))
 
     econtext = @inferred ExecContext()
 
-    params = [0.0 -0.3; 0.0 0.3]
+    params = [0.0 -0.3 0.5; 0.0 0.3 0.6]
 
     @testset "rand" begin
         td = test_density()
@@ -53,7 +53,7 @@ BAT.sampler(td::test_density) = BAT.sampler(MvNormal(ones(3), PDMat(eye(3))))
     end
 
     @testset "density_logval!" begin
-        r = zeros(Float64, 2)
+        r = zeros(Float64, size(params, 2))
 
         density_logval!(r, density, params, econtext)
         @test r ≈ logpdf(mvnorm, params)


### PR DESCRIPTION
The number of parameters and the number of calls to the density are unrelated. In the unit test, it happened to be 2D and 2 calls. Overly symmetric tests are evil!