### PR TITLE
Pre-install HDF5.jl during CI testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ branches:
 notifications:
   email: false
 
+before_script:
+  - julia -e 'using Pkg; pkg"add HDF5"'
+
 after_success:
   # push coverage results to Codecov
   - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
@@ -59,6 +62,8 @@ jobs:
         - latex --version
       env:
         - GKSwstype=nul
+      before_script:
+        - julia -e 'using Pkg; pkg"add HDF5"'
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl


### PR DESCRIPTION
Workaround for current problems with HDF5/Blosc/Compat version
compatibility.