### PR TITLE
Problem with truncated uniform distribution 

### DIFF
--- a/src/densities/truncated_density.jl
+++ b/src/densities/truncated_density.jl
@@ -75,7 +75,11 @@ function truncate_dist_hard(dist::Distribution{Univariate}, bounds::Interval)
     hi = clamp(max(lo, maximum(bounds)), min_lo, max_hi)
 
     trunc_dist = truncated(dist, lo, hi)
-    logrenorm = trunc_dist.logtp
+    if dist isa Uniform
+        logrenorm = log(trunc_dist.b - trunc_dist.a) - log(dist.b - dist.a)
+    else
+        logrenorm = trunc_dist.logtp
+    end
     return (dist = trunc_dist, logrenorm = logrenorm)
 end
 
@@ -89,7 +93,11 @@ function truncate_dist_hard(dist::Truncated, bounds::Interval)
     lo = clamp(max(minimum(bounds), dist.lower), min_lo, max_hi)
     hi = clamp(max(lo, min(maximum(bounds), dist.upper)), min_lo, max_hi)
     trunc_dist = truncated(untrunc_dist, lo, hi)
-    logrenorm = trunc_dist.logtp - dist.logtp
+    if untrunc_dist isa Uniform
+        logrenorm = log(trunc_dist.b - trunc_dist.a) - log(dist.b - dist.a)
+    else
+        logrenorm = trunc_dist.logtp - dist.logtp
+    end
     return (dist = trunc_dist, logrenorm = logrenorm)
 end
 


### PR DESCRIPTION
Uniform distribution does not have `logtp`, so I was not able to truncate it:
```julia
ntdist = NamedTupleDist(a = Uniform(-1,1))
prior = convert(AbstractDensity, ntdist)
bounds = BAT.HyperRectBounds([0..1,], BAT.hard_bounds)
tr_dist = BAT.truncate_density(prior, bounds);
```
```terminal
type Uniform has no field logtp
Stacktrace:
 [1] getproperty(::Uniform{Float64}, ::Symbol) at ./Base.jl:33
 [2] truncate_dist_hard(::Uniform{Float64}, ::Interval{:closed,:closed,Float64}) at /Users/vhafych/MPP-Server/gitrepos/BAT.jl/src/densities/truncated_density.jl:78
```
For the `Uniform` distribution `logrenorm` can be defined as `log(trunc_dist.b - trunc_dist.a) - log(dist.b - dist.a)`. 
Can we merge this workaround? 