### PR TITLE
Kolmogorov-Smirnov Goodness of Fit Test

### DIFF
--- a/docs/src/experimental_api.md
+++ b/docs/src/experimental_api.md
@@ -6,6 +6,7 @@ Instead, compatibility is only guaranteed across changes in patch version, but
 *not* across changes of minor (or major) version changes.
 
 ```@docs
+bat_compare
 BAT.ExternalDensity
 BAT.FunnelDistribution
 BAT.MultimodalCauchy

--- a/src/statistics/ks_test.jl
+++ b/src/statistics/ks_test.jl
@@ -1,14 +1,5 @@
 # This file is a part of BAT.jl, licensed under the MIT License (MIT).
 
-function ApproximateTwoSampleKSTest(
-        x::AbstractVector{T},
-        y::AbstractVector{S},
-        w_x::AbstractVector{D},
-        w_y::AbstractVector{M}) where {T<:Real, S<:Real, D<:Real, M<:Real}
-    HypothesisTests.ApproximateTwoSampleKSTest(ksstats(x, y, w_x, w_y)...)
-end
-export ApproximateTwoSampleKSTest
-
 function ksstats(
         x::AbstractVector{T},
         y::AbstractVector{S},
@@ -16,38 +7,85 @@ function ksstats(
         w_y::AbstractVector{M}
     ) where {T<:Real, S<:Real, D<:Real, M<:Real}
 
-    n_x, n_y = length(w_x), length(w_y) # ToDo: sum(w_x), length(w_x) or bat_eff_sample_size(...)
     sort_idx = sortperm([x; y])
     pdf_diffs = [w_x/sum(w_x); -w_y/sum(w_y)][sort_idx]
     cdf_diffs = cumsum(pdf_diffs)
     δp = maximum(cdf_diffs)
     δn = -minimum(cdf_diffs)
     δ = max(δp, δn)
-    (n_x, n_y, δ, δp, δn)
+    (δ, δp, δn)
 end
 
-function bat_compare(samples_1::DensitySampleVector, samples_2::DensitySampleVector)
+"""
+    bat_compare(
+        samples_1::DensitySampleVector,
+        samples_2::DensitySampleVector;
+        nsamples::Symbol=:effective
+    )
 
-    n_params = size(flatview(unshaped.(samples_2.v)))[1]
-    p_values_array = Float64[]
+Compares two `DensitySampleVector`s given by `samples_1` and `samples_2` applying the Kolmogorov-Smirnov test for all marginals.
+
+`nsamples` specifies how to define a number of samples in the Kolmogorov-Smirnov
+distribution. The default value is `nsamples=:effective`, which uses the
+effective number of samples estimated by `bat_eff_sample_size`. The optimal keywords:
+
+* `:length`  — length of the `DensitySamplesVector` is used
+
+* `:weights` — the sum of the weights is used
+
+Returns a NamedTuple of the shape
+
+```julia
+(result = X::TypedTables.Table, ...)
+```
+"""
+function bat_compare(samples_1::DensitySampleVector, samples_2::DensitySampleVector;  nsamples::Symbol=:effective)
+
+    n_params_1 = size(flatview(unshaped.(samples_1.v)))[1]
+    n_params_2 = size(flatview(unshaped.(samples_2.v)))[1]
+
+    if n_params_1 !== n_params_2
+        throw(ArgumentError("Samples with different number of parameters cannot be compared"))
+    end
 
     samples_1_flat = flatview(unshaped.(samples_1.v))
     samples_2_flat = flatview(unshaped.(samples_2.v))
 
-    for param_ind in Base.OneTo(n_params)
-        test_result = ApproximateTwoSampleKSTest(
-            samples_1_flat[param_ind, :],
-            samples_2_flat[param_ind, :],
-            samples_1.weight,
-            samples_2.weight
-        )
-        push!(p_values_array, HypothesisTests.pvalue(test_result))
+    if nsamples == :effective
+        @info "Using effective number of samples in the Kolmogorov–Smirnov distribution"
+        smpl_size_1 = round.(Int64, bat_eff_sample_size(unshaped.(samples_1)).result)
+        smpl_size_2 = round.(Int64, bat_eff_sample_size(unshaped.(samples_2)).result)
+    elseif nsamples == :length
+        @info "Using lengths of the vectors in the Kolmogorov–Smirnov distribution"
+        length_1 = length(samples_1)
+        length_2 = length(samples_1)
+        smpl_size_1 = repeat([length_1], n_params_1)
+        smpl_size_2 = repeat([length_2], n_params_2)
+    elseif nsamples == :weights
+        @info "Using sum of the weights in the Kolmogorov–Smirnov distribution"
+        tot_weights_1 = sum(samples_1.weight)
+        tot_weights_2 = sum(samples_2.weight)
+        smpl_size_1 = repeat([tot_weights_1], n_params_1)
+        smpl_size_2 = repeat([tot_weights_2], n_params_2)
+    else
+        throw(ArgumentError("Unknown keyword"))
     end
 
-    # ToDo: Add Chi-squared test; Use bat_eff_sample_size to estimate n_x, n_y
-    # Return: TypedTables.Table(dims = Base.OneTo(n_params), ks_p_values = p_values_array, cs_p_values = [...])
+    p_values_array = map(i-> begin
+        test_result = ksstats( samples_1_flat[i, :], samples_2_flat[i, :], samples_1.weight, samples_2.weight)
+        ks_test = HypothesisTests.ApproximateTwoSampleKSTest(smpl_size_1[i], smpl_size_2[i], test_result...)
+        HypothesisTests.pvalue(ks_test)
+    end, Base.OneTo(n_params_1))
 
-    return TypedTables.Table(dims = Base.OneTo(n_params), ks_p_values = p_values_array)
+    table_result = TypedTables.Table(
+            dim_ind = Base.OneTo(n_params_1), # indices of parameters
+            nsamples_1 = smpl_size_1, # number of samples for `samples_1`
+            nsamples_2 = smpl_size_2, # number of samples for `samples_2`
+            ks_p_values = p_values_array, # Kolmogorov-Smirnov p-values
+            # additional tests can be added to this table/function later
+    )
+
+    return (result=table_result, )
 end
 
 export bat_compare


### PR DESCRIPTION
Hi @oschulz, @salvolc. I have improved `bat_compare` function so that it can now use different ways to treat a number of samples is the Kolmogorov-Smirnov test. By default, it will use an effective number of samples (alternatively, the length of the sample vector can be used, or the sum of its weights). This function can be used now to run final benchmarks for the paper. 

@salvolc, updated `bat_compare` function works in the same way as the previous one. The only small difference is that results are returned in a form of a `NamedTuple`, so you should run `bat_compare(sample_1, sample_2).result`. 