### PR TITLE
Plotting now allows to specify bin edges

### DIFF
--- a/docs/src/plotting.md
+++ b/docs/src/plotting.md
@@ -32,7 +32,8 @@ Keyword arguments:
     * `:central_intervals`
     * `:histogram`, alias `:steppost`
     * `:stephist` (default for prior)
-* `nbins::Integer = 200`: number of histogram bins
+
+* `bins::Union{Integer, AbstractRange} = 200`: number of histogram bins or bin edges.
 
 * `normalize::Bool = true`: normalize the histogram
 
@@ -69,6 +70,7 @@ plot(
     intervals = standard_confidence_vals,
 	interval_labels = [],
     colors = standard_colors,
+	bins = 200,
     mean = false,
     std = false,
     globalmode = false,
@@ -93,7 +95,8 @@ Keyword arguments:
 	* `:histogram`, alias `:hist`, alias `:histogram2d`
     * `:scatter`
 
-* `nbins::Union{Integer, NTuple{2, Integer}} = 200`: number of histogram bins, use a `NTuple{2, Integer}` to specify bins of x and y axes seperately
+
+* `bins::Union{Integer, NTuple{2, Integer}, NTuple{2, AbstractRange}} = 200`: number of histogram bins or bin edges. Use a `NTuple{2, Union{Integer, AbstractRange}}` to specify bins/edges of x and y axes seperately.
 
 * `normalize::Bool = true`: normalize the histogram
 
@@ -131,6 +134,7 @@ Keyword arguments for [attributes supported by *Plots.jl*](https://docs.juliaplo
 plot(
 	samples::DensitySampleVector / prior::NamedTupleDist;
     vsel=collect(1:5),
+	bins = 200,
     mean=false,
     std=false,
     globalmode=false,
@@ -147,7 +151,8 @@ Required inputs:
   * `samples::DensitySampleVector` or `prior::NamedTupleDist`: samples (shaped or unshaped) or prior to be plotted
 
 Keyword arguments:
-  * `vsel::Array{Integer, 1} = collect(1:5)`: indices of the parameters to be plotted. By default (up to) the first five parameters are plotted.
+  * `vsel = collect(1:5)`: indices or parameter names of the parameters to be plotted. By default (up to) the first five parameters are plotted.
+  * `bins::Union{Integer, Tuple{Union{Integer, AbstractRange}}, NamedTuple} = 200`: Number of bins or bin edges
   * `mean::Bool = false`: Indicate mean value, calculated via  `bat_stats().mean`, in all plots (currently only for samples)
   * `std::Bool = false`: Indicate the standard deviation of the mean calculated from `bat_stats().cov` in all plots (currently only for samples)
   * `globalmode::Bool = false`: Indicate global mode, calculated via `bat_stats().mode`, in all plots (currently only for samples)

--- a/examples/dev-internal/plotting_examples.jl
+++ b/examples/dev-internal/plotting_examples.jl
@@ -166,7 +166,7 @@ plot(samples, (:a,:(b[2])), seriestype=:smallest_intervals, nbins=200,
 # By passing `true`, the point estimators are plotted using their default styles shown above.
 # The style of the point estimators *mean*, *globalmode* and *localmode* can be modified by passing a dictionary specifying `markershape`, `markercolor`, `markersize`, `markeralpha`, `markerstrokecolor`, `markerstrokestyle`, `markerstrokewidth` and `markerstrokealpha`.
 # If `std==true`, the standard deviation of the mean value will be displayed as x- and y-errorbars.
-plot(samples, (:a,:(b[2])), seriestype=:smallest_intervals, bins=(200, 100),
+plot(samples, (:a,:(b[2])), seriestype=:smallest_intervals, bins=(200, -4:0.2:8),
     localmode=Dict("markershape"=> :diamond, "markeralpha"=>1, "markercolor"=>:red, "markersize"=>5),
     mean = true, std=true
 )

--- a/examples/dev-internal/plotting_examples.jl
+++ b/examples/dev-internal/plotting_examples.jl
@@ -84,7 +84,7 @@ plot(samples, :a, seriestype = :stephist)
 # ## Customizing 1D plots:
 
 # ### Keyword arguments for [attributes supported by *Plots.jl*](https://docs.juliaplots.org/latest/attributes/#attributes-1) can be passed:
-plot(samples, :a, seriestype = :stephist, nbins=50, linecolor = :red, linewidth = 5, linealpha=0.4, xlim=(-10,10))
+plot(samples, :a, seriestype = :stephist, bins=50, linecolor = :red, linewidth = 5, linealpha=0.4, xlim=(-10,10))
 
 # ### Customizing interval plots:
 # For `:smallest_intervals` and `:central_intervals` plot, the probability enclosed in the intervals to be highlighted can be specified using the `intervals` keyword.
@@ -144,7 +144,7 @@ plot(samples, (:a,:(b[2])), seriestype=:smallest_intervals_contourf, bins=40)
 # The probability intervals to be highlighted can be specified using the `intervals` keyword.
 # The keyword `interval_labels` allows to specify the legend entries for the corresponding intervals (in same order).
 # The interval colors need to be specified (in same order) using the `colors` keyword argument.
-plot(samples, (:a,:(b[2])), seriestype=:smallest_intervals, nbins=200,
+plot(samples, (:a,:(b[2])), seriestype=:smallest_intervals, bins=200,
 intervals=[0.7, 0.2],
 interval_labels = ["HDR 70%", "HDR 20%"],
 colors=[:blue, :red])
@@ -166,7 +166,7 @@ plot(samples, (:a,:(b[2])), seriestype=:smallest_intervals, nbins=200,
 # By passing `true`, the point estimators are plotted using their default styles shown above.
 # The style of the point estimators *mean*, *globalmode* and *localmode* can be modified by passing a dictionary specifying `markershape`, `markercolor`, `markersize`, `markeralpha`, `markerstrokecolor`, `markerstrokestyle`, `markerstrokewidth` and `markerstrokealpha`.
 # If `std==true`, the standard deviation of the mean value will be displayed as x- and y-errorbars.
-plot(samples, (:a,:(b[2])), seriestype=:smallest_intervals, nbins=200,
+plot(samples, (:a,:(b[2])), seriestype=:smallest_intervals, bins=(200, 100),
     localmode=Dict("markershape"=> :diamond, "markeralpha"=>1, "markercolor"=>:red, "markersize"=>5),
     mean = true, std=true
 )
@@ -190,18 +190,23 @@ plot(prior)
 plot(samples)
 plot!(prior)
 
-# The keyword argument `vsel` allows to specify which parameters to consider in the overview plot by passing the indeces:
-plot(samples, vsel=[1, 3])
+# The keyword argument `vsel` allows to specify which parameters to consider in the overview plot by passing the names or indeces:
+plot(samples, vsel=(:a, :(b[2])))
+# or: plot(samples, vsel=(1, 3))
+
+# The binning of the overview plots can be specified individually for each parameter:
+plot(samples, bins=200) # all paramaters have 200 bins (default)
+plot(samples, bins=(10, -5:0.5:8, 500)) #  specify different bin numbers or bin edges for each parameter (only those specified with vsel)
+plot(prior, bins=(a=50,)) # use 50 bins for parameter :a and the default value (200) for all others
 
 # ### Customizing overview plots:
 # The overview plots can be modified by passing dictionaries to the keyword arguments `upper`, `lower` and `diagonal`.
 # The dictionaries for `upper` and `lower` can contain the 2D seriestypes and plot options shown above.
 # The dictionary for `diagonal` can use the 1D seriestypes and plot options shown above.
 # Nested dictonaries are possible (e.g. for modifying point estimators)
-plot(samples, mean=true, globalmode=true, legend=true,
+plot(samples, mean=true, globalmode=true, legend=true, bins = (a = -15:2:15, ),
     diagonal=Dict("seriestype"=>:stephist, "mean"=>Dict("linecolor" => :green, "linewidth" => 8)),
     lower = Dict("mean" => false, "colors"=>[:orange, :green, :grey]))
-
 
 # ## Plots for MCMC diagnostics
 # The diagnostic plots allow to plot the samples, a kernel density estimate, the trace and the autocorrelation function for each parameter and each chain:

--- a/src/plotting/recipes_prior.jl
+++ b/src/plotting/recipes_prior.jl
@@ -24,7 +24,7 @@
     marg = bat_marginalize(
         prior,
         idx,
-        nbins = bins,
+        bins = bins,
         nsamples = nsamples,
         closed = closed,
         normalize = normalize
@@ -93,7 +93,7 @@ end
     marg = bat_marginalize(
         prior,
         (xidx, yidx),
-        nbins = bins,
+        bins = bins,
         closed = closed,
         normalize = normalize
     ).result

--- a/src/plotting/recipes_samples_1D.jl
+++ b/src/plotting/recipes_samples_1D.jl
@@ -24,7 +24,7 @@
     marg = bat_marginalize(
         maybe_shaped_samples,
         parsel,
-        nbins = bins,
+        bins = bins,
         closed = closed,
         filter = filter,
         normalize = normalize

--- a/src/plotting/recipes_samples_2D.jl
+++ b/src/plotting/recipes_samples_2D.jl
@@ -7,7 +7,6 @@
     colors = standard_colors,
     mean = false,
     std = false,
-    edges = [],
     globalmode = false,
     localmode = true,
     diagonal = Dict(),

--- a/src/plotting/recipes_samples_2D.jl
+++ b/src/plotting/recipes_samples_2D.jl
@@ -7,6 +7,7 @@
     colors = standard_colors,
     mean = false,
     std = false,
+    edges = [],
     globalmode = false,
     localmode = true,
     diagonal = Dict(),
@@ -47,7 +48,7 @@
     marg = bat_marginalize(
         samples,
         (xindx, yindx),
-        nbins = bins,
+        bins = bins,
         closed = closed,
         filter = filter
     ).result


### PR DESCRIPTION
Binning of plots can now not only be passed as the number of bins but also by specifying the bin edges as a `Range`.
Examples:
```
plot(samples, :a, bins = -10:0.1:10)
plot(samples, (:a, :b), bins = (50, -10:0.1:10))

plot(samples, bins =  (50, -10:0.1:10))
plot(samples, bins = (a = 50, b = -5:0.5:5))
```
Also,  `vsel` now accepts indices and parameter names.

@oschulz The only problem we now have is that the syntax in the fourth line of the example code above does not work for multivariate parameters, since expressions like e.g. `:(b[1])` are not allowed as names in a `NamedTuple`. 
I remember we already discussed going back to something like `b_1` etc. So maybe we should consider doing this now?