### PR TITLE
Don't use StructArrays.StructArrayStyle explicitly

### DIFF
--- a/src/transforms/abstract_variate_transform.jl
+++ b/src/transforms/abstract_variate_transform.jl
@@ -108,7 +108,7 @@ end
 
 function Base.copy(
     instance::Base.Broadcast.Broadcasted{
-        <:Union{Base.Broadcast.AbstractArrayStyle{1},StructArrays.StructArrayStyle},
+        <:Base.Broadcast.AbstractArrayStyle,
         <:Any,
         <:AbstractVariateTransform,
         <:Tuple{DensitySampleVector}
@@ -251,7 +251,7 @@ import Base.∘
 
 function Base.copy(
     instance::Base.Broadcast.Broadcasted{
-        <:Union{Base.Broadcast.AbstractArrayStyle{1},StructArrays.StructArrayStyle},
+        <:Base.Broadcast.AbstractArrayStyle,
         <:Any,
         <:IdentityVT,
         <:Tuple{<:Union{ArrayOfSimilarVectors{<:Real},ShapedAsNTArray,DensitySampleVector}}

--- a/src/variates/density_sample.jl
+++ b/src/variates/density_sample.jl
@@ -233,7 +233,7 @@ end
 
 Base.copy(
     instance::Base.Broadcast.Broadcasted{
-        <:Union{Base.Broadcast.AbstractArrayStyle{1},StructArrays.StructArrayStyle},
+        <:Base.Broadcast.AbstractArrayStyle,
         <:Any,
         <:Union{AbstractValueShape,typeof(unshaped)},
         <:Tuple{DensitySampleVector}


### PR DESCRIPTION
For backward compatibility with StructArrays v0.4.