### PR TITLE
Adds test for RandResampling and OrderedResampling test to test_bat_sample.jl

### DIFF
--- a/test/samplers/test_bat_sample.jl
+++ b/test/samplers/test_bat_sample.jl
@@ -49,7 +49,7 @@ using Random, Distributions, StatsBase
         dist = MvNormal([0.4, 0.6], [2.0 1.2; 1.2 3.0])
         result = @inferred(bat_sample(dist, IIDSampling(nsamples = 10^5))).result
 
-        #@test length(@inferred(bat_sample(result, OrderedResampling(nsamples = 10^3))).result) == 10^3#Commented out: fails but looks intended behav?
+        @test isapprox(mean([length(@inferred(bat_sample(result, OrderedResampling(nsamples = 10))).result.v) for i in 1:10^3]), 10, rtol = 10^-1)
 
         @test @inferred(bat_sample(Random.GLOBAL_RNG, result)).result isa DensitySampleVector#Check that types are consistent
         @test @inferred(bat_sample(result, BAT.OrderedResampling())).result isa DensitySampleVector

--- a/test/samplers/test_bat_sample.jl
+++ b/test/samplers/test_bat_sample.jl
@@ -20,9 +20,6 @@ using Random, Distributions, StatsBase
         @test isapprox(mean(samples.v), [0.4, 0.6]; rtol = 0.05)
         @test isapprox(cov(samples.v), [2.0 1.2; 1.2 3.0]; rtol = 0.05)
         @test all(isequal(1), samples.weight)
-        
-        resamples = @inferred(bat_sample(samples, OrderedResampling(nsamples = length(samples)))).result
-        @test samples == resamples
 
         dist_bmode = @inferred(bat_findmode(dist)).result
         @test @inferred(length(dist_bmode)) == 2
@@ -31,5 +28,35 @@ using Random, Distributions, StatsBase
         @test @inferred(length(dist_sample_vector_bmode)) == 2
 
         isapprox(var(bat_sample(Normal(), BAT.IIDSampling(nsamples = 10^3)).result), [1], rtol = 10^-1)
+    end
+    @testset "RandResampling" begin
+        dist = Normal()
+        result = @inferred(bat_sample(dist, IIDSampling(nsamples = 2))).result #Draw to samples from Normal dist
+
+        
+
+        @test @inferred(bat_sample(Random.GLOBAL_RNG, result)).result isa DensitySampleVector#Check data types 
+        @test @inferred(bat_sample(result, RandResampling(nsamples = 100))).result isa DensitySampleVector
+        @test @inferred(bat_sample(Random.GLOBAL_RNG, result, BAT.RandResampling())).result isa DensitySampleVector
+
+        
+        samples_rdm = @inferred(bat_sample(result, RandResampling(nsamples = 10^5))).result.v#Sample 100 times from the 2-sample space
+        @test length(@inferred(bat_sample(result, RandResampling(nsamples = 100))).result) == 100#Check shape is ok
+        @test sort(unique(samples_rdm)) == sort(result.v)#check it only samples from the 2-sample space
+        @test isapprox(mean(samples_rdm), mean(result.v), rtol = 10^-1)#means should be the same in both datasets
+    end
+    @testset "OrderedResampling" begin #Creates new testset for OrderedResampling
+        dist = MvNormal([0.4, 0.6], [2.0 1.2; 1.2 3.0])
+        result = @inferred(bat_sample(dist, IIDSampling(nsamples = 10^5))).result
+
+        #@test length(@inferred(bat_sample(result, OrderedResampling(nsamples = 10^3))).result) == 10^3#Commented out: fails but looks intended behav?
+
+        @test @inferred(bat_sample(Random.GLOBAL_RNG, result)).result isa DensitySampleVector#Check that types are consistent
+        @test @inferred(bat_sample(result, BAT.OrderedResampling())).result isa DensitySampleVector
+        @test @inferred(bat_sample(Random.GLOBAL_RNG, result, BAT.OrderedResampling())).result isa DensitySampleVector
+
+        resamples = @inferred(bat_sample(result, OrderedResampling(nsamples = length(result)))).result
+        @test result == resamples
+        
     end
 end


### PR DESCRIPTION
Hi @oschulz (I could not assign you as a reviewer so I hope this is ok)

This PR includes test for the three functions in the bat_samples module and only modifies the test_bat_samples.jl file. 

In this script I added tests for RandResampling and moved the one that existed for OrderedResampling to another test set together with more tests (do you agree with this organisation change?). 

There's one strange behaviour in OrderedResampling that I'm not sure is intended, this behaviour will make the following test fail (that's why it's commented out in line 52 of the script):

`@test length(@inferred(bat_sample(result, OrderedResampling(nsamples = 10^3))).result) == 10^3`

Basically the output vector doesn't have in general the number of samples that's specified with the `n_samples` parameter.  If `nsamples = length(result)` then the test passes.  

**To reproduce the issue:**

- `dist = Normal()`
- `result = (bat_sample(dist, IIDSampling(nsamples = 12))).result`
- `length((bat_sample(result, OrderedResampling(nsamples = 15))).result.v)` Run this several times and you'll get different results

The different lengths come in the source code from only accepting the sample with probability n/m (n = No. samples in result, m No. samples in `OrderedResampling`) (line 126 [src](https://github.com/bat/BAT.jl/blob/eaa6fe8a4fdda48a44d20d932cde8377ca1310b2/src/samplers/bat_sample.jl))


Is this intended? 