### PR TITLE
Resolve type instablity of logpdf for multimodal cauchy

### DIFF
--- a/src/distributions/multimodal_cauchy.jl
+++ b/src/distributions/multimodal_cauchy.jl
@@ -60,7 +60,7 @@ function StatsBase.params(d::MultimodalCauchy)
 end
 
 function Distributions._logpdf(d::MultimodalCauchy, x::AbstractArray)
-    Distributions._logpdf(d.dist, x)
+    convert(eltype(x), Distributions._logpdf(d.dist, x))::eltype(x)
 end
 
 function Distributions._rand!(rng::AbstractRNG, d::MultimodalCauchy, x::AbstractVector)


### PR DESCRIPTION
Fixes type instability for multimodal cauchy from PR #289, e.g.
```
mmc = BAT.MultimodalCauchy(μ = 1., σ = 0.1, n=4)
@code_warntype Distributions._logpdf(mmc, [-1., 0., 1., 2.])
```