### PR TITLE
[WIP] Tests for modified partitioned sampling

### DIFF
--- a/test/samplers/partitioned_sampling/test_partitioned_sampling.jl
+++ b/test/samplers/partitioned_sampling/test_partitioned_sampling.jl
@@ -10,7 +10,7 @@ using Distributions, LinearAlgebra, ValueShapes
     μ = [1 1 1; -1 1 0; -1 -1 -1; 1 -1 0]
     mixture_model = MixtureModel(MvNormal[MvNormal(μ[i,:], Matrix(Hermitian(σ)) ) for i in 1:4])
     # ToDo: Use more complex prior with non-uniform distribution
-    prior = NamedTupleDist(a = [Uniform(-2,2), Uniform(-2,2), Uniform(-2, 2)])
+    prior = NamedTupleDist(a = [Normal(0,2), Normal(0,2), Normal(0, 2)])
     likelihood = let model = mixture_model
         params -> LogDVal(logpdf(model, params.a))
     end
@@ -20,20 +20,22 @@ using Distributions, LinearAlgebra, ValueShapes
 
     #Sampling and integration algorithms
     mcmc = MCMCSampling(mcalg = MetropolisHastings(), nsteps = 10^3);
-    #vegas = BAT.VEGASIntegration(trafo = NoDensityTransform(), rtol = 0.001, atol = 1.0e-8)
     ahmi = ahmi = AHMIntegration(whitening = BAT.NoWhitening(), max_startingIDs = 10^3)
-    sobol = BAT.SobolSampler(nsamples = 500)
-    #mcmc_exp = MCMCSampling(mcalg = MetropolisHastings(), nchains =4, nsteps = 400, trafo = NoDensityTransform(),);
+    #sobol = BAT.SobolSampler(nsamples = 500)
+    mcmc_exp = MCMCSampling(mcalg = MetropolisHastings(), nsteps = 1000, nchains=20, strict=false)
 
-    ps = PartitionedSampling(sampler = mcmc, npartitions=4, exploration_sampler=sobol, integrator = ahmi);
+    ps = PartitionedSampling(sampler = mcmc, npartitions=4, exploration_sampler=mcmc_exp, integrator = ahmi, nmax_resampling=5);
 
 
     #Sampling with space partition
     results = bat_sample(posterior , ps)
     
     #Kolmogorov-Smirnov Test
-    mcmc_samples = @inferred(bat_sample(posterior, mcmc))#sample from original pdf with MCMC
-    ks_test = bat_compare(mcmc_samples.result, results.result)#Run Kolmogorov-Smirnov test
+    #mcmc_samples = @inferred(bat_sample(posterior, mcmc))#sample from original pdf with MCMC
+    #mcmc_samples =bat_sample(posterior, mcmc) #sample from original pdf with MCMC
+    iid_distribution = NamedTupleDist(a = mixture_model,)
+    iid_samples = bat_sample(iid_distribution, IIDSampling(nsamples=10^6))
+    ks_test = bat_compare(iid_samples.result, results.result)#Run Kolmogorov-Smirnov test
     @test all(ks_test.result.ks_p_values .> 0.7)#Check that all the p-values are bigger than 0.7
     @testset "Array of Posteriors" begin
         posteriors_array = BAT.convert_to_posterior(transformed_posterior, results.part_tree, extend_bounds = true)


### PR DESCRIPTION
Hi @VasylHafych 

Maybe we can discuss here the tests for your extension of partition sampling. As far as I understood you added two new features: re-sampling of subspaces when the convergence is not reached (up to a certain number of times spececified by `nmax_resampling`) and the transformation of the prior to make it uniform. I modified a bit the testing script I had to include a non-uniform prior, a Gaussian and changed the algorithms a bit. Is this in the direction you want? A few comments:

* There might be some type instability in line 34 that makes @inferred fail in bat_sample, test fails if I leave it.
*  I got an error while using Sobol sampler when resampling subspaces. The exception said Sobol didn't have a `nstep`  parameter so it looks like resampling only accepts mcmc for the moment, right? I changed exploration alg to mcmc and worked
*  For the histogram comparison you said in the email we should compare iid to space partitioning, is this preferred above mcmc vs space partitioning? I  implemented both and simply commented mcmc out to leave iid. I understood that's what you wanted, let me know if that's not the case.

Please let me know of any general comments you have.