### PR TITLE
Tests for log_uniform.jl

### DIFF
--- a/test/distributions/test_distribution_functions.jl
+++ b/test/distributions/test_distribution_functions.jl
@@ -4,7 +4,7 @@ using BAT
 using Test
 
 using LinearAlgebra, Random
-using Distributions, PDMats, StatsBase, SparseArrays
+using Distributions, PDMats, StatsBase
 
 
 @testset "distribution_functions" begin
@@ -28,7 +28,6 @@ using Distributions, PDMats, StatsBase, SparseArrays
         @test BAT.cov2pdmat(Float64, PDMat(Matrix(1.0I, 2, 2))) == PDMat(Matrix(1.0I, 2, 2))
         @test BAT.cov2pdmat(Float64, PDiagMat([1, 1])) == BAT.cov2pdmat(Float64, Matrix(PDiagMat([1, 1])))
         @test BAT.cov2pdmat(Float64, ScalMat(2, 3)) == BAT.cov2pdmat(Float64, Matrix(ScalMat(2, 3)))
-        @test BAT.cov2pdmat(Float64, PDSparseMat(sparse(Matrix(1.0I, 2, 2)))) == BAT.cov2pdmat(Float64, Matrix(PDSparseMat(sparse(Matrix(1.0I, 2, 2)))))
         @test BAT.cov2pdmat(Float64, cholesky(Matrix(1.0I, 2, 2))) == PDMat(cholesky(Matrix(1.0I, 2, 2)))
         @test BAT.cov2pdmat(Float16, cholesky(Matrix(1.0I, 2, 2))) == BAT.cov2pdmat(Float16, Matrix(1.0I, 2, 2))
     end

--- a/test/distributions/test_distribution_functions.jl
+++ b/test/distributions/test_distribution_functions.jl
@@ -23,4 +23,12 @@ using Distributions, PDMats, StatsBase
         @test BAT.issymmetric_around_origin(MvTDist(1.5, zeros(2), PDMat(Matrix{Float64}(I, 2, 2))))
         @test BAT.issymmetric_around_origin(MvTDist(1.5, ones(2), PDMat(Matrix{Float64}(I, 2, 2)))) == false
     end
+    @testset "BAT.cov2pdmat" begin 
+        @test BAT.cov2pdmat(Float64, PDMat(Matrix(1.0I, 2, 2))) == PDMat(Matrix(1.0I, 2, 2))
+        @test BAT.cov2pdmat(Float64, PDiagMat([1, 1])) == BAT.cov2pdmat(Float64, Matrix(PDiagMat([1, 1])))
+        @test BAT.cov2pdmat(Float64, ScalMat(2, 3)) == BAT.cov2pdmat(Float64, Matrix(ScalMat(2, 3)))
+        @test BAT.cov2pdmat(Float64, PDSparseMat(sparse(Matrix(1.0I, 2, 2)))) == BAT.cov2pdmat(Float64, Matrix(PDSparseMat(sparse(Matrix(1.0I, 2, 2)))))
+        @test BAT.cov2pdmat(Float64, cholesky(Matrix(1.0I, 2, 2))) == PDMat(cholesky(Matrix(1.0I, 2, 2)))
+        @test BAT.cov2pdmat(Float16, cholesky(Matrix(1.0I, 2, 2))) == BAT.cov2pdmat(Float16, Matrix(1.0I, 2, 2))
+    end
 end

--- a/test/distributions/test_distribution_functions.jl
+++ b/test/distributions/test_distribution_functions.jl
@@ -4,7 +4,7 @@ using BAT
 using Test
 
 using LinearAlgebra, Random
-using Distributions, PDMats, StatsBase
+using Distributions, PDMats, StatsBase, SparseArrays
 
 
 @testset "distribution_functions" begin
@@ -23,6 +23,7 @@ using Distributions, PDMats, StatsBase
         @test BAT.issymmetric_around_origin(MvTDist(1.5, zeros(2), PDMat(Matrix{Float64}(I, 2, 2))))
         @test BAT.issymmetric_around_origin(MvTDist(1.5, ones(2), PDMat(Matrix{Float64}(I, 2, 2)))) == false
     end
+
     @testset "BAT.cov2pdmat" begin 
         @test BAT.cov2pdmat(Float64, PDMat(Matrix(1.0I, 2, 2))) == PDMat(Matrix(1.0I, 2, 2))
         @test BAT.cov2pdmat(Float64, PDiagMat([1, 1])) == BAT.cov2pdmat(Float64, Matrix(PDiagMat([1, 1])))


### PR DESCRIPTION
Added some tests for functions and definitions in the log_uniform.jl file.

I assumed the definition in line 33 of the src file:

LogUniform() = LogUniform{Float64}(0, 1)

is supposed to catch an empty input as an argument error since the first arg needs to be finite per definition.
