### PR TITLE
extended test coverage for log_uniform.jl

### DIFF
--- a/src/distributions/log_uniform.jl
+++ b/src/distributions/log_uniform.jl
@@ -30,7 +30,7 @@ function LogUniform(a::Real, b::Real)
     LogUniform{T}(a, b)
 end
 
-LogUniform() = LogUniform{Float64}(0, 1)
+LogUniform() = LogUniform{Float64}(1, 2)
 
 
 Base.minimum(d::LogUniform{T}) where T = d.a

--- a/test/distributions/test_log_uniform.jl
+++ b/test/distributions/test_log_uniform.jl
@@ -20,7 +20,7 @@ using StatsBase, FillArrays
     d = BAT.LogUniform(0.1, 100)
     X = @inferred(rand(stblrng(), d, 10^5))
     
-    @test_throws ArgumentError BAT.LogUniform()  
+    @test BAT.LogUniform() == BAT.LogUniform{Float64}(1, 2)  
 
     @test params(d) == (0.1, 100)
     @test @inferred(minimum(d)) == 0.1


### PR DESCRIPTION
I assumed the definition in line 33 of the src file:

LogUniform() = LogUniform{Float64}(0, 1)

 is supposed to catch an empty input as an arg error since the first arg of LogUniform needs to be finite per definition.