### PR TITLE
Fix: don't use deterministic rng values for mode finding

### DIFF
--- a/src/initvals/initvals.jl
+++ b/src/initvals/initvals.jl
@@ -137,11 +137,11 @@ export InitFromSamples
 
 
 function bat_initval_impl(rng::AbstractRNG, target::AnyDensityLike, algorithm::InitFromSamples)
-    (result = _rand_v(rng, target, algorithm.samples),)
+    (result = _rand_v_for_target(rng, target, algorithm.samples),)
 end
 
 function bat_initval_impl(rng::AbstractRNG, target::AnyDensityLike, n::Integer, algorithm::InitFromSamples)
-    (result = _rand_v(rng, target, algorithm.samples, n),)
+    (result = _rand_v_for_target(rng, target, algorithm.samples, n),)
 end
 
 
@@ -163,11 +163,11 @@ export InitFromIID
 
 
 function bat_initval_impl(rng::AbstractRNG, target::AnyDensityLike, algorithm::InitFromIID)
-    (result = _rand_v(rng, target, algorithm.src),)
+    (result = _rand_v_for_target(rng, target, algorithm.src),)
 end
 
 function bat_initval_impl(rng::AbstractRNG, target::AnyDensityLike, n::Integer, algorithm::InitFromIID)
-    (result = _rand_v(rng, target, algorithm.src, n),)
+    (result = _rand_v_for_target(rng, target, algorithm.src, n),)
 end
 
 

--- a/src/optimization/findmode_optim.jl
+++ b/src/optimization/findmode_optim.jl
@@ -16,11 +16,10 @@ function (gf::NLSolversFG!)(val_f::Nothing, grad_f::Any, v::Any)
     return Nothing
 end
 
-
 function _bat_findmode_impl_optim(target::AnySampleable, algorithm::AbstractModeEstimator)
     transformed_density, trafo = transform_and_unshape(algorithm.trafo, target)
 
-    rng = bat_determ_rng()
+    rng = bat_rng()
     initalg = apply_trafo_to_init(trafo, algorithm.init)
     x_init = collect(bat_initval(rng, transformed_density, initalg).result)
 


### PR DESCRIPTION
Fix 1: no longer use deterministic rng vlaues for initial values when using `bat_findmode`
Fix 2: use `_rand_v_for_target` when using `InitFromIID` and `InitFromSamples`