### PR TITLE
Allow to use Distributions.ReshapedDistributions in prior

### DIFF
--- a/src/densities/distribution_density.jl
+++ b/src/densities/distribution_density.jl
@@ -86,6 +86,8 @@ dist_param_bounds(d::StandardNormalDist) =
 
 dist_param_bounds(d::ReshapedDist) = dist_param_bounds(unshaped(d))
 
+dist_param_bounds(d::Distributions.ReshapedDistribution) = dist_param_bounds(unshaped(d))
+
 dist_param_bounds(d::Product{Continuous}) =
     HyperRectBounds(minimum.(d.v), maximum.(d.v))
 

--- a/src/distributions/distribution_functions.jl
+++ b/src/distributions/distribution_functions.jl
@@ -13,6 +13,8 @@ eff_totalndof(d::ConstValueDist) = 0
 eff_totalndof(d::NamedTupleDist) = sum(map(eff_totalndof, values(d)))
 eff_totalndof(d::ValueShapes.UnshapedNTD) = eff_totalndof(d.shaped)
 eff_totalndof(d::ReshapedDist) = eff_totalndof(unshaped(d))
+eff_totalndof(d::Distributions.ReshapedDistribution) = eff_totalndof(BAT.unshaped(d))
+
 
 
 

--- a/src/transforms/distribution_transform.jl
+++ b/src/transforms/distribution_transform.jl
@@ -399,6 +399,16 @@ function apply_dist_trafo(trg_d::Distribution{Univariate,Continuous}, ::Standard
     _eval_dist_trafo_func(_trafo_quantile, trg_d, mod_src_v)
 end
 
+function apply_dist_trafo(
+    trg_d::Distributions.ReshapedDistribution,
+    src_d::StdMvDist,
+    src_v::Base.ReshapedArray
+)
+    src_v_flat = view(src_v, :)
+    unshaped_trg = unshaped(trg_d)
+    apply_dist_trafo(unshaped_trg, src_d, src_v_flat)
+end
+
 
 
 function _dist_trafo_rescale_impl(trg_d, src_d, src_v::Real)


### PR DESCRIPTION
Allows to use matrix-shaped product distributions in the prior without flattening:
```
prior = BAT.NamedTupleDist(ShapedAsNT,
    a = reshape(product_distribution(fill(Normal(5. , 0.1), 4)), 2,2,1),
)

llikelihood = logfuncdensity(v -> begin
        p = v.a[1,2,1]

        result = logpdf(Normal(1., 0.5), p)

        return result
end)
```

Co-authored-by: Arne Gottwald <arnegottwald@uni-bonn.de>