### PR TITLE
Use `track_order = true` in IO via HDF5.jl

### DIFF
--- a/src/io/bat_io.jl
+++ b/src/io/bat_io.jl
@@ -38,7 +38,21 @@ function bat_read(src::Union{AbstractString,Tuple{AbstractString, AbstractString
     ftype = _file_type_from_extension(src)
     if ftype == "HDF5"
         _h5io_open(src, "r") do input
-            (result = _h5io_read(input),)
+            #=
+                Currently (HDF5.jl - v0.16.9), the keyword `track_order` is ignored in read-in. 
+                Thus, HDF5.IDX_TYPE[] has to be set manually.
+                The try-catch-block is necessary in order to be able to load old files.
+            =#
+            prev = HDF5.IDX_TYPE[] 
+            HDF5.IDX_TYPE[] = HDF5.API.H5_INDEX_CRT_ORDER
+            r = try
+                (result = _h5io_read(input),)
+            catch err
+                HDF5.IDX_TYPE[] = prev
+                (result = _h5io_read(input),)
+            end
+            HDF5.IDX_TYPE[] = prev
+            r            
         end
     else
         throw(ArgumentError("Unknown file type $ftype"))

--- a/src/io/hdf5.jl
+++ b/src/io/hdf5.jl
@@ -19,7 +19,7 @@ _h5io_add_path_to_dest(dest, path::AbstractString) = (dest, path)
 
 function _h5io_write!(dest_with_subpath::Tuple{Any,AbstractString}, data::AbstractArray{<:Real})
     dest, path = dest_with_subpath
-    if occursin('/', path)
+    if occursin('/', path) && _h5_track_order_available()
         group_name = dirname(path)
         dataset_name = basename(path)
         g = if !haskey(dest, group_name)


### PR DESCRIPTION
This fixes #355

The read-in requires some modification of internal HDF5 parameters at the moment.
I also opened an issue in HDF5.jl: https://github.com/JuliaIO/HDF5.jl/issues/939

Please have a look @oschulz 