### PR TITLE
WIP: changed to transform_and_unshape in bat_sample_impl

### DIFF
--- a/src/samplers/mcmc/chain_pool_init.jl
+++ b/src/samplers/mcmc/chain_pool_init.jl
@@ -22,11 +22,14 @@ end
 
 export MCMCChainPoolInit
 
-apply_trafo_to_init(trafo::Function, initalg::MCMCChainPoolInit) = MCMCChainPoolInit(
+
+function apply_trafo_to_init(trafo::Function, initalg::MCMCChainPoolInit)
+    MCMCChainPoolInit(
     initalg.init_tries_per_chain,
     initalg.nsteps_init,
     apply_trafo_to_init(trafo, initalg.initval_alg)
-)
+    )
+end
 
 
 
@@ -38,7 +41,8 @@ function _construct_chain(
     initval_alg::InitvalAlgorithm
 )
     rng = AbstractRNG(rngpart, id)
-    v_init = unshaped(bat_initval(rng, density, initval_alg).result, varshape(density))
+    v_init = bat_initval(rng, density, initval_alg).result
+
     MCMCIterator(rng, algorithm, density, id, v_init)
 end
 

--- a/src/samplers/mcmc/mcmc_sample.jl
+++ b/src/samplers/mcmc/mcmc_sample.jl
@@ -43,10 +43,9 @@ function bat_sample_impl(
     target::AnyDensityLike,
     algorithm::MCMCSampling
 )
+    
     density_notrafo = convert(AbstractDensity, target)
-    shaped_density, trafo = bat_transform(algorithm.trafo, density_notrafo)
-    density = unshaped(shaped_density)
-
+    density, trafo = transform_and_unshape(algorithm.trafo, density_notrafo)
     mcmc_algorithm = algorithm.mcalg
 
     (chains, tuners, chain_outputs) = mcmc_init!(
@@ -87,7 +86,7 @@ function bat_sample_impl(
 
     output = DensitySampleVector(first(chains))
     isnothing(output) || append!.(Ref(output), chain_outputs)
-    samples_trafo = varshape(shaped_density).(output)
+    samples_trafo = varshape(density).(output)
 
     samples_notrafo = inverse(trafo).(samples_trafo)
 

--- a/src/samplers/mcmc/mh/mh_tuner.jl
+++ b/src/samplers/mcmc/mh/mh_tuner.jl
@@ -94,7 +94,7 @@ _approx_cov(target::DensityWithDiff) = _approx_cov(parent(target))
 function tuning_init!(tuner::ProposalCovTuner, chain::MHIterator, max_nsteps::Integer)
     Σ_unscaled = _approx_cov(getdensity(chain))
     Σ = Σ_unscaled * tuner.scale
-
+    
     chain.proposaldist = set_cov(chain.proposaldist, Σ)
 
     nothing


### PR DESCRIPTION
Line 41 in `chain_pool_init.jl` didn't work for `trafo = NoDensityTransform`.

By changing from `bat_transform` to `transform_and_unshape` in `mcmc_sample.jl` this is solved.
However, in `mcmc_sample.jl` I now completely replaced the old trafo by the unshaping trafo. This gives the correct results with the only difference being that now also for `trafo = NoDensityTransform` the `samples.result_trafo` are unshaped (as they are for `PriorToGaussian` and `PriorToUniform`). Before, for `NoDensityTransform` `samples.result` and `samples.result_trafo` were the same. 

I find this now a bit more consistent since users can now be sure that `samples.result_trafo` is always unshaped. 
But this would require some adaptions to the other sampling algorithms to behave the same way (shouldn't be that much).
I'm not sure if we want to go in that direction or if I should just pass the "unshaping" trafo only to the `initval` algorithm.