### PR TITLE
Fix plotting and make bat_marginalize() consistent with BAT API

### DIFF
--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -30,7 +30,7 @@ function MarginalDist(
 
     marg_samples = bat_marginalize(samples, vsel)
     vs = varshape(marg_samples)
-    shapes = [getproperty(acc, :shape) for acc in vs._accessors]
+    vs isa NamedTupleShape ? shapes = [getproperty(acc, :shape) for acc in vs._accessors] :
     UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,)))
 
     if filter

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -42,8 +42,10 @@ function MarginalDist(
 
     edges = if isa(bins, Integer)
         _get_edges(cols, (bins,), closed)
-    else
-        Tuple(_get_edges(cols[i], bins[i] isa Real ? Integer(bins[i]) : bins[i], closed) for i in 1:length(bins))
+    elseif bins isa Tuple
+        Tuple(_get_edges(cols[i], bins[i] i, closed) for i in 1:length(bins))
+    else 
+        _get_edges(cols, bins, closed)
     end
 
     hist = fit(Histogram, cols, edges, closed = closed)

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -31,7 +31,7 @@ function MarginalDist(
     marg_samples = bat_marginalize(samples, vsel)
     vs = varshape(marg_samples)
     shapes = [getproperty(acc, :shape) for acc in vs._accessors]
-    UV = length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,))
+    UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,)))
 
     if filter
         marg_samples = BAT.drop_low_weight_samples(marg_samples)

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -31,7 +31,7 @@ function MarginalDist(
     marg_samples = bat_marginalize(samples, vsel)
     vs = varshape(marg_samples)
     shapes = [getproperty(acc, :shape) for acc in vs._accessors]
-    UV = all(broadcast(shape -> shape isa ScalarShape, shapes)) || (length(shapes) == 1 && getproperty(shapes[1], :dims) == (1,))
+    UV = length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,))
 
     if filter
         marg_samples = BAT.drop_low_weight_samples(marg_samples)

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -45,7 +45,7 @@ function MarginalDist(
     elseif bins isa Tuple
         Tuple(_get_edges(cols[i], bins[i], closed) for i in 1:length(bins))
     else 
-        _get_edges(cols, bins, closed)
+        Tuple(_get_edges(cols, bins, closed))
     end
 
     hist = fit(Histogram, cols, FrequencyWeights(samples.weight), edges, closed = closed)

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -32,12 +32,6 @@ function MarginalDist(
     vs = varshape(marg_samples)
     vs isa NamedTupleShape ? shapes = [getproperty(acc, :shape) for acc in vs._accessors] : shapes = [0,0]
     UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,)))
-    
-    if bins isa Tuple
-        for i in 1:length(bins)
-            bins[i] = bins[i] isa Real ? Integer(bins[i]) : bins[i]
-        end
-    end
 
     if filter
         marg_samples = BAT.drop_low_weight_samples(marg_samples)
@@ -49,7 +43,7 @@ function MarginalDist(
     edges = if isa(bins, Integer)
         _get_edges(cols, (bins,), closed)
     else
-        Tuple(_get_edges(cols[i], bins[i], closed) for i in 1:length(bins))
+        Tuple(_get_edges(cols[i], bins[i] isa Real ? Integer(bins[i]) : bins[i], closed) for i in 1:length(bins))
     end
 
     hist = fit(Histogram, cols, edges, closed = closed)

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -23,7 +23,7 @@ end
 function MarginalDist(
     samples::Union{DensitySampleVector, StructArrays.StructVector},
     vsel;
-    bins = 200, #::Union{I, Vector{I}, Tuple{I}} where I<:Integer
+    bins::Union{I, Tuple{I}, R, Tuple{R}} where I<:Integer where R<:AbstractRange = 200,
     closed::Symbol = :left,
     filter::Bool = false
 )
@@ -40,7 +40,6 @@ function MarginalDist(
     marg_samples = flatview(unshaped.(marg_samples).v)
     cols = Tuple(Vector.(eachrow(marg_samples)))
 
-    bins = Integer.(bins)
     edges = if isa(bins, Integer)
         _get_edges(cols, (bins,), closed)
     else

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -23,7 +23,7 @@ end
 function MarginalDist(
     samples::Union{DensitySampleVector, StructArrays.StructVector},
     vsel;
-    bins::Union{I, Tuple{I}, R, Tuple{R}} where I<:Integer where R<:AbstractRange = 200,
+    bins::Union{I, R, Tuple{Union{I, R}}} where I<:Integer where R<:AbstractRange = 200,
     closed::Symbol = :left,
     filter::Bool = false
 )

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -40,6 +40,7 @@ function MarginalDist(
     marg_samples = flatview(unshaped.(marg_samples).v)
     cols = Tuple(Vector.(eachrow(marg_samples)))
 
+    bins = Integer.(bins)
     edges = if isa(bins, Integer)
         _get_edges(cols, (bins,), closed)
     else

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -43,7 +43,7 @@ function MarginalDist(
     edges = if isa(bins, Integer)
         _get_edges(cols, (bins,), closed)
     elseif bins isa Tuple
-        Tuple(_get_edges(cols[i], bins[i] i, closed) for i in 1:length(bins))
+        Tuple(_get_edges(cols[i], bins[i], closed) for i in 1:length(bins))
     else 
         _get_edges(cols, bins, closed)
     end

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -48,7 +48,7 @@ function MarginalDist(
         _get_edges(cols, bins, closed)
     end
 
-    hist = fit(Histogram, cols, edges, closed = closed)
+    hist = fit(Histogram, cols, FrequencyWeights(samples.weight), edges, closed = closed)
 
     binned_dist = UV ? EmpiricalDistributions.UvBinnedDist(hist) : EmpiricalDistributions.MvBinnedDist(hist)
     binned_dist = UV ? binned_dist : vs(binned_dist) isa ReshapedDist ? vs(binned_dist) : ReshapedDist(vs(binned_dist), vs)

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -28,7 +28,7 @@ function MarginalDist(
     filter::Bool = false
 )
 
-    marg_samples = bat_marginalize(samples, vsel)
+    marg_samples = bat_marginalize(samples, vsel).result
     vs = varshape(marg_samples)
     vs isa NamedTupleShape ? shapes = [getproperty(acc, :shape) for acc in vs._accessors] : shapes = [0,0]
     UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,)))

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -23,7 +23,7 @@ end
 function MarginalDist(
     samples::Union{DensitySampleVector, StructArrays.StructVector},
     vsel;
-    bins::Union{I, R, Tuple{Union{I, R}}} where I<:Integer where R<:AbstractRange = 200,
+    bins = 200,
     closed::Symbol = :left,
     filter::Bool = false
 )
@@ -32,6 +32,12 @@ function MarginalDist(
     vs = varshape(marg_samples)
     vs isa NamedTupleShape ? shapes = [getproperty(acc, :shape) for acc in vs._accessors] : shapes = [0,0]
     UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,)))
+    
+    if bins isa Tuple
+        for i in 1:lenght(bins)
+            bins[i] = bins[i] isa Real ? Integer(bins[i]) : bins[i]
+        end
+    end
 
     if filter
         marg_samples = BAT.drop_low_weight_samples(marg_samples)

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -30,7 +30,7 @@ function MarginalDist(
 
     marg_samples = bat_marginalize(samples, vsel)
     vs = varshape(marg_samples)
-    vs isa NamedTupleShape ? shapes = [getproperty(acc, :shape) for acc in vs._accessors] :
+    vs isa NamedTupleShape ? shapes = [getproperty(acc, :shape) for acc in vs._accessors] : shapes = [0,0]
     UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,)))
 
     if filter

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -45,7 +45,7 @@ function MarginalDist(
     elseif bins isa Tuple
         Tuple(_get_edges(cols[i], bins[i], closed) for i in 1:length(bins))
     else 
-        Tuple(_get_edges(cols, bins, closed))
+        (_get_edges(cols, bins, closed),)
     end
 
     hist = fit(Histogram, cols, FrequencyWeights(samples.weight), edges, closed = closed)

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -34,7 +34,7 @@ function MarginalDist(
     UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,)))
     
     if bins isa Tuple
-        for i in 1:lenght(bins)
+        for i in 1:length(bins)
             bins[i] = bins[i] isa Real ? Integer(bins[i]) : bins[i]
         end
     end

--- a/src/plotting/MarginalDist_utils.jl
+++ b/src/plotting/MarginalDist_utils.jl
@@ -9,7 +9,7 @@ Find the modes of a MarginalDist.
 Returns a vector of the bin-centers of the bin(s) with the heighest weight.
 """
 function find_marginalmodes(marg::MarginalDist)
-    hist = convert(Histogram, marg.dist.dist)
+    hist = convert(Histogram, marg.dist isa ReshapedDist ? marg.dist.dist : marg.dist)
     dims = ndims(hist.weights)
 
     max = maximum(hist.weights)
@@ -29,7 +29,7 @@ end
 Returns a vector of the bin-centers.
 """
 function get_bin_centers(marg::MarginalDist)
-    hist = convert(Histogram, marg.dist.dist)
+    hist = convert(Histogram, marg.dist isa ReshapedDist ? marg.dist.dist : marg.dist)
     edges = hist.edges
     dims = ndims(hist.weights)
 

--- a/src/plotting/recipes_MarginalDist_1D.jl
+++ b/src/plotting/recipes_MarginalDist_1D.jl
@@ -23,7 +23,7 @@ end
     else 
         marg = MarginalDist(origmarg, vsel)
     end
-    hist = convert(Histogram, marg.dist.dist)
+    hist = convert(Histogram, marg.dist isa ReshapedDist ? marg.dist.dist : marg.dist)
 
     orientation = get(plotattributes, :orientation, :vertical)
     (orientation != :vertical) ? swap = true : swap = false

--- a/src/plotting/recipes_MarginalDist_1D.jl
+++ b/src/plotting/recipes_MarginalDist_1D.jl
@@ -13,12 +13,12 @@ end
 
 @recipe function f(
     origmarg::MarginalDist,
-    vsel::Union{Integer, Symbol, Expr} = :novsel;
+    vsel::Union{Nothing, Integer, Symbol, Expr} = nothing;
     intervals = default_credibilities,
     colors = default_colors,
     interval_labels = []
 )   
-    if vsel == :novsel
+    if vsel === nothing
         marg = origmarg
     else 
         marg = MarginalDist(origmarg, vsel)
@@ -31,8 +31,11 @@ end
 
     seriestype = get(plotattributes, :seriestype, :stephist)
 
-    xlabel = get(plotattributes, :xguide, vsel isa Integer ? "x$(vsel)" : "$vsel")
-    ylabel = get(plotattributes, :yguide, vsel isa Integer ? "p(x$(vsel))" : "p($vsel)")
+    xl = vsel === nothing ? "x" : vsel isa Integer ? "x$(vsel)" : "$vsel"
+    yl = vsel === nothing ? "p(x)" : vsel isa Integer ? "p(x$(vsel))" : "p($vsel)"
+
+    xlabel = get(plotattributes, :xguide, xl)
+    ylabel = get(plotattributes, :yguide, yl)
 
     if swap
         xguide := ylabel

--- a/src/plotting/recipes_MarginalDist_2D.jl
+++ b/src/plotting/recipes_MarginalDist_2D.jl
@@ -12,7 +12,7 @@
     normalize = true
 )
     _plots_module() != nothing || throw(ErrorException("Package Plots not available, but required for this operation"))
-    hist = convert(Histogram, marg.dist.dist)
+    hist = convert(Histogram, marg.dist isa ReshapedDist ? marg.dist.dist : marg.dist)
     seriestype = get(plotattributes, :seriestype, :histogram2d)
 
     xlabel = get(plotattributes, :xguide, "x$(vsel[1])")

--- a/src/plotting/recipes_prior.jl
+++ b/src/plotting/recipes_prior.jl
@@ -87,7 +87,7 @@ end
 
     marg = MarginalDist(
         prior,
-        (xidx, yidx),
+        vsel,
         bins = bins,
         closed = closed
     )
@@ -110,6 +110,6 @@ end
         upper --> upper
         right --> right
 
-        marg, (xidx, yidx)
+        marg, vsel
     end
 end

--- a/src/plotting/recipes_prior.jl
+++ b/src/plotting/recipes_prior.jl
@@ -22,7 +22,7 @@
 
     marg = MarginalDist(
         prior,
-        idx,
+        vsel,
         bins = bins,
         closed = closed,
         nsamples = nsamples

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -38,7 +38,7 @@
     elseif isa(bins, NamedTuple)
         tmp_bins::Vector{Any} = fill(200, length(vsel))
         for k in keys(bins)
-            idx = findfirst(isequal(string(k)), getstring.(Ref(prior), vsel))
+            idx = findfirst(isequal(string(k)), getstring.(Ref(prior), [1:length(vsel)]))
             tmp_bins[idx] = bins[idx]
         end
         tmp_bins

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -118,10 +118,14 @@ function _all_exprs(dist::NamedTupleDist)
 
     for (i,sym) in enumerate(syms)
         vsel_tmp = Expr[]
-        for id in 1:lengths[i]
-            push!(vsel_tmp, Meta.parse("$sym[$id]"))
-        end
 
+        if lengths[i] == 1 
+            push!(vsel_tmp, Meta.parse("$sym"))
+        else
+            for id in 1:lengths[i]
+                push!(vsel_tmp, Meta.parse("$sym[$id]"))
+            end
+        end
         push!(vsel, vsel_tmp...)
     end
 

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -15,6 +15,8 @@
         vsel = reduce(vcat, vsel)
     end
     vsel = vsel[vsel .<=  totalndof(BAT.varshape(prior))]
+    all_exprs = _all_exprs(prior)
+    vsel = all_exprs[vsel]
 
     xlabel = [getstring(prior, i) for i in vsel]
     ylabel = ["p($l)" for l in xlabel]
@@ -105,4 +107,23 @@
         end
     end
 
+end
+
+function _all_exprs(dist::NamedTupleDist)
+    vs = varshape(dist)
+    accs = vs._accessors
+    syms = keys(accs)
+    lengths = length.(values(accs))
+    vsel = Expr[]
+
+    for (i,sym) in enumerate(syms)
+        vsel_tmp = Expr[]
+        for id in 1:lengths[i]
+            push!(vsel_tmp, Meta.parse("$sym[$id]"))
+        end
+
+        push!(vsel, vsel_tmp...)
+    end
+
+    return vsel
 end

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -18,7 +18,7 @@
     all_exprs = _all_exprs(prior)
     vsel = all_exprs[vsel]
 
-    xlabel = [getstring(prior, i) for i in vsel]
+    xlabel = string.[vsel]
     ylabel = ["p($l)" for l in xlabel]
 
     if length(vsel_label) > 0

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -18,7 +18,7 @@
     all_exprs = _all_exprs(prior)
     vsel = all_exprs[vsel]
 
-    xlabel = string.[vsel]
+    xlabel = string.(vsel)
     ylabel = ["p($l)" for l in xlabel]
 
     if length(vsel_label) > 0

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -114,10 +114,10 @@ function _all_exprs(dist::NamedTupleDist)
     accs = vs._accessors
     syms = keys(accs)
     lengths = length.(values(accs))
-    vsel = Expr[]
+    vsel = Any[]
 
     for (i,sym) in enumerate(syms)
-        vsel_tmp = Expr[]
+        vsel_tmp = Any[]
 
         if lengths[i] == 1 
             push!(vsel_tmp, Meta.parse("$sym"))

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -38,7 +38,7 @@
     elseif isa(bins, NamedTuple)
         tmp_bins::Vector{Any} = fill(200, length(vsel))
         for k in keys(bins)
-            idx = findfirst(isequal(string(k)), getstring.(Ref(prior), [1:length(vsel)]))
+            idx = findfirst(isequal(string(k)), getstring.(Ref(prior), Vector(1:length(vsel))))
             tmp_bins[idx] = bins[idx]
         end
         tmp_bins

--- a/src/plotting/recipes_samples_1D.jl
+++ b/src/plotting/recipes_samples_1D.jl
@@ -64,7 +64,7 @@
     #------ stats ----------------------------
     stats = MCMCBasicStats(maybe_shaped_samples)
 
-    line_height = maximum(convert(Histogram, marg.dist.dist).weights)*1.03
+    line_height = maximum(convert(Histogram, marg.dist isa ReshapedDist ? marg.dist.dist : marg.dist).weights)*1.03
 
     mean_options = convert_to_options(mean)
     globalmode_options = convert_to_options(globalmode)

--- a/src/plotting/recipes_samples_2D.jl
+++ b/src/plotting/recipes_samples_2D.jl
@@ -25,8 +25,10 @@
         throw(ArgumentError("Symbol :$(vsel[2]) refers to a multivariate parameter. Use :($(vsel[2])[i]) instead."))
     end
 
+    vs = varshape(maybe_shaped_samples)
     samples = unshaped.(maybe_shaped_samples)
     filter ? samples = BAT.drop_low_weight_samples(samples) : nothing
+    reshaped_samples = vs.(samples)
 
     bins = get(plotattributes, :bins, 200)
     seriestype = get(plotattributes, :seriestype, :smallest_intervals)
@@ -46,7 +48,7 @@
     yguide := get(plotattributes, :yguide, ylabel)
 
     marg = MarginalDist(
-        samples,
+        reshaped_samples,
         vsel,
         bins = bins,
         closed = closed,

--- a/src/plotting/recipes_samples_2D.jl
+++ b/src/plotting/recipes_samples_2D.jl
@@ -47,7 +47,7 @@
 
     marg = MarginalDist(
         samples,
-        (xindx, yindx),
+        vsel,
         bins = bins,
         closed = closed,
         filter = filter

--- a/src/plotting/recipes_samples_2D.jl
+++ b/src/plotting/recipes_samples_2D.jl
@@ -97,7 +97,7 @@
             right --> right
             smoothing --> smoothing
 
-            marg, vsel
+            marg, (1,2)
         end
     end
 

--- a/src/plotting/recipes_samples_2D.jl
+++ b/src/plotting/recipes_samples_2D.jl
@@ -97,7 +97,7 @@
             right --> right
             smoothing --> smoothing
 
-            marg, (xindx, yindx)
+            marg, vsel
         end
     end
 

--- a/src/plotting/vsel_processing.jl
+++ b/src/plotting/vsel_processing.jl
@@ -167,7 +167,7 @@ end
 Create a new `DensitySampleVector` containing the selected 
 dimensions `vsel` of the input `samples`.
 
-Returns a `DensitySampleVector`. If the input is shaped, the new samples
+Returns a NamedTuple `(result = marg_samples::DensitySampleVector)`. If the input is shaped, the new samples
 will have the shape of the selected dimensions.
 
 `samples` may be shaped or unshaped, vsel may be an `Int`, `UnitRange`, 
@@ -240,5 +240,5 @@ function bat_marginalize(samples::DensitySampleVector,
     aux = samples.aux
 
     marg_samples = shaped ? new_shape.(DensitySampleVector(marg_data, logd, info = info, aux = aux)) : DensitySampleVector(marg_data, logd, info = info, aux = aux)
-    return marg_samples
+    return (result = marg_samples,)
 end


### PR DESCRIPTION
Fix many bugs that would brake plotting utilities

This is now tested for each case included in /BAT.jl/examples/dev-internal/plotting_examples.jl, so plotting should be much more reliable now.

Other changes:
    - bat_marginalize() now returns a `NamedTuple` `(result = marg_samples::DensitySampleVector, )`
    - if the input samples or distribution of MarginalDist() are univariate, the generated MarginalDist will be unshaped