### PR TITLE
Add flat index support for bat_marginalize()

### DIFF
--- a/examples/dev-internal/plotting_examples.jl
+++ b/examples/dev-internal/plotting_examples.jl
@@ -3,6 +3,7 @@
 using BAT
 using Distributions
 using IntervalSets
+using DensityInterface
 
 # ## Generate samples to be plotted
 likelihood = logfuncdensity(params -> begin

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -31,7 +31,7 @@ function MarginalDist(
     marg_samples = bat_marginalize(samples, vsel).result
     vs = varshape(marg_samples)
     vs isa NamedTupleShape ? shapes = [getproperty(acc, :shape) for acc in vs._accessors] : shapes = [0,0]
-    UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa ScalarShape || getproperty(shapes[1], :dims) == (1,)))
+    UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa Union{ScalarShape, ConstValueShape} || getproperty(shapes[1], :dims) == (1,)))
 
     if filter
         marg_samples = BAT.drop_low_weight_samples(marg_samples)

--- a/src/plotting/MarginalDist_utils.jl
+++ b/src/plotting/MarginalDist_utils.jl
@@ -208,7 +208,7 @@ function calculate_levels(
     return sort(levels)
 end
 
-function _all_exprs(vs::AbstractValueShape)
+function _all_exprs(vs::NamedTupleShape)
     accs = vs._accessors
     syms = keys(accs)
     lengths = length.(values(accs))
@@ -230,7 +230,7 @@ function _all_exprs(vs::AbstractValueShape)
     return exprs
 end
 
-function _all_exprs_as_strings(vs::AbstractValueShape)
+function _all_exprs_as_strings(vs::NamedTupleShape)
     accs = vs._accessors
     syms = keys(accs)
     lengths = length.(values(accs))

--- a/src/plotting/MarginalDist_utils.jl
+++ b/src/plotting/MarginalDist_utils.jl
@@ -207,3 +207,47 @@ function calculate_levels(
     levels[end] = 1.1*sum_of_weights
     return sort(levels)
 end
+
+function _all_exprs(vs::AbstractValueShape)
+    accs = vs._accessors
+    syms = keys(accs)
+    lengths = length.(values(accs))
+    exprs = Union{Expr, Symbol, Union{Expr, Symbol}}[]
+
+    for (i,sym) in enumerate(syms)
+        exprs_tmp = Any[]
+
+        if lengths[i] == 1 
+            push!(exprs_tmp, Meta.parse("$sym"))
+        else
+            for id in 1:lengths[i]
+                push!(exprs_tmp, Meta.parse("$sym[$id]"))
+            end
+        end
+        push!(exprs, exprs_tmp...)
+    end
+
+    return exprs
+end
+
+function _all_exprs_as_strings(vs::AbstractValueShape)
+    accs = vs._accessors
+    syms = keys(accs)
+    lengths = length.(values(accs))
+    expr_strings = String[]
+
+    for (i,sym) in enumerate(syms)
+        expr_strings_tmp = Any[]
+
+        if lengths[i] == 1 
+            push!(expr_strings_tmp, "$sym")
+        else
+            for id in 1:lengths[i]
+                push!(expr_strings_tmp, "$sym[$id]")
+            end
+        end
+        push!(expr_strings, expr_strings_tmp...)
+    end
+
+    return expr_strings
+end

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -10,12 +10,13 @@
     vsel_label = []
 )
     vsel = collect(vsel)
+    vs = BAT.varshape(prior)
     if isa(vsel, Vector{<:Integer}) == false
-        vsel = asindex.(Ref(BAT.varshape(prior)), vsel)
+        vsel = asindex.(Ref(vs), vsel)
         vsel = reduce(vcat, vsel)
     end
-    vsel = vsel[vsel .<=  totalndof(BAT.varshape(prior))]
-    all_exprs = _all_exprs(prior)
+    vsel = vsel[vsel .<=  totalndof(vs)]
+    all_exprs = _all_exprs(vs)
     vsel = all_exprs[vsel]
 
     xlabel = string.(vsel)
@@ -107,27 +108,4 @@
         end
     end
 
-end
-
-function _all_exprs(dist::NamedTupleDist)
-    vs = varshape(dist)
-    accs = vs._accessors
-    syms = keys(accs)
-    lengths = length.(values(accs))
-    vsel = Any[]
-
-    for (i,sym) in enumerate(syms)
-        vsel_tmp = Any[]
-
-        if lengths[i] == 1 
-            push!(vsel_tmp, Meta.parse("$sym"))
-        else
-            for id in 1:lengths[i]
-                push!(vsel_tmp, Meta.parse("$sym[$id]"))
-            end
-        end
-        push!(vsel, vsel_tmp...)
-    end
-
-    return vsel
 end

--- a/src/transforms/distribution_transform.jl
+++ b/src/transforms/distribution_transform.jl
@@ -455,18 +455,21 @@ end
 
 std_dist_from(src_d::MvNormal) = StandardMvNormal(length(src_d))
 
+_cholesky_L(A) = cholesky(A).L
+_cholesky_L(A::Diagonal{<:Real}) = Diagonal(sqrt.(diag(A)))
+_cholesky_L(A::PDiagMat{<:Real}) = Diagonal(sqrt.(A.diag))
+_cholesky_L(A::ScalMat{<:Real}) = Diagonal(Fill(sqrt(A.value), A.dim))
+
 function apply_dist_trafo(trg_d::StandardMvNormal, src_d::MvNormal, src_v::AbstractVector{<:Real})
     @argcheck length(trg_d) == length(src_d)
-    A = cholesky(src_d.Σ).U
-    transpose(A) \ (src_v - src_d.μ)
+    _cholesky_L(src_d.Σ) \ (src_v - src_d.μ)
 end
 
 std_dist_to(trg_d::MvNormal) = StandardMvNormal(length(trg_d))
 
 function apply_dist_trafo(trg_d::MvNormal, src_d::StandardMvNormal, src_v::AbstractVector{<:Real})
     @argcheck length(trg_d) == length(src_d)
-    A = cholesky(trg_d.Σ).U
-    transpose(A) * src_v + trg_d.μ
+    _cholesky_L(trg_d.Σ) * src_v + trg_d.μ
 end
 
 


### PR DESCRIPTION
Adds support for doing 

marg_s = BAT.bat_marginalize(some_shaped_samples, i)

where `i` is an Integer, Vector or Tuple of Integers or Unit Range.

The new marginalized samples will have `N` ScalarShaped parameters with the keys being encoded according to the keys of the input data. `N` being the number of columns selected in the marginalization process.

If a range is input, Expressions corresponding to the selected columns will be generated up to a range of 5. For larger ranges strings will be used to create the encoded symbols to save memory.
