### PR TITLE
Switch Recipes PriorOverview _all_expr -> _all_active_expr

### DIFF
--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -15,8 +15,8 @@
         vsel = reduce(vcat, vsel)
     end
     vsel = vsel[vsel .<=  totalndof(BAT.varshape(prior))]
-    all_exprs = _all_exprs(prior)
-    vsel = all_exprs[vsel]
+    all_active_exprs = _all_active_exprs(prior)
+    vsel = all_active_exprs[vsel]
 
     xlabel = string.(vsel)
     ylabel = ["p($l)" for l in xlabel]

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -2,7 +2,7 @@
 
 @recipe function f(
     prior::NamedTupleDist;
-    vsel=collect(1:5),
+    vsel::AbstractVector=collect(1:5),
     bins = 200,
     diagonal = Dict(),
     upper = Dict(),


### PR DESCRIPTION
A element of prior can be const. So far these are not plotted (and there probably is no need to anyways). This patch reenables to plot overview on priors which have constant elements aka number of elements in _all_active_expr is smaller then in _all_expr.

One could open up a TODO to plot prior overviews by Symbol and Expr as well (those are the accepted `vsel` arguments for a single plot)