### PR TITLE
Switch Recipes PriorOverview _all_exprs -> _all_active_exprs

### DIFF
--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -15,8 +15,8 @@
         vsel = reduce(vcat, vsel)
     end
     vsel = vsel[vsel .<=  totalndof(BAT.varshape(prior))]
-    all_exprs = _all_exprs(prior)
-    vsel = all_exprs[vsel]
+    all_active_exprs = _all_active_exprs(prior)
+    vsel = all_active_exprs[vsel]
 
     xlabel = string.(vsel)
     ylabel = ["p($l)" for l in xlabel]

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -2,7 +2,7 @@
 
 @recipe function f(
     prior::NamedTupleDist;
-    vsel=collect(1:5),
+    vsel::AbstractVector=collect(1:5),
     bins = 200,
     diagonal = Dict(),
     upper = Dict(),

--- a/src/plotting/recipes_prior_overview.jl
+++ b/src/plotting/recipes_prior_overview.jl
@@ -109,20 +109,22 @@
 
 end
 
-function _all_exprs(dist::NamedTupleDist)
+function _all_active_exprs(dist::NamedTupleDist)
     vs = varshape(dist)
     accs = vs._accessors
     syms = keys(accs)
-    lengths = length.(values(accs))
     vsel = Any[]
 
     for (i,sym) in enumerate(syms)
         vsel_tmp = Any[]
 
-        if lengths[i] == 1 
+	lengths_i = getproperty(vs, sym).len
+	if lengths_i == 0
+           skip
+        elseif lengths_i == 1 
             push!(vsel_tmp, Meta.parse("$sym"))
         else
-            for id in 1:lengths[i]
+            for id in 1:lengths_i
                 push!(vsel_tmp, Meta.parse("$sym[$id]"))
             end
         end


### PR DESCRIPTION
A element of prior can be const. So far these are not plotted (and there probably is no need to anyways). This patch reenables to plot overview on priors which have constant elements aka number of elements in totalndof/_all_active_exprs is smaller than in implementation _all_exprs.

One could open up a TODO to plot prior overviews by Symbol and Expr as well (those are the accepted vsel arguments for a single plot)

Additional work needs to be done if a element should be displayed with the same shape, as it is provided by a ShapedAsNT prior.
