### PR TITLE
Fix revert to functional rand(::HierarchicalDistribution)

### DIFF
--- a/src/distributions/hierarchical_distribution.jl
+++ b/src/distributions/hierarchical_distribution.jl
@@ -189,14 +189,25 @@ end
 =#
 
 function _hd_split(ud::UnshapedHDist, x::AbstractVector{<:Real})
-    @argcheck eff_totalndof(ud) == length(eachindex(x))
+    @argcheck length(ud) == length(eachindex(x))
     np = length(_hd_pridist(ud))
+
+    __hd_split(ud, x, np)
+end
+
+function __hd_split(ud::UnshapedHDist, x::AbstractVector{<:Real}, np::Integer)
     idxs = eachindex(x)
     idxs_primary = first(idxs):(first(idxs) + np - 1)
     idxs_secondary = (first(idxs) + np):last(idxs)
     (view(x, idxs_primary), view(x, idxs_secondary))
 end
 
+function _hd_split_efftotalndof(ud::UnshapedHDist, x::AbstractVector{<:Real})
+    @argcheck eff_totalndof(ud) == length(eachindex(x))
+    np = eff_totalndof(_hd_pridist(ud))
+
+    __hd_split(ud, x, np)
+end
 
 function Distributions.logpdf(ud::UnshapedHDist, x::AbstractVector{<:Real})
     x_primary, x_secondary = _hd_split(ud, x)

--- a/src/distributions/hierarchical_distribution.jl
+++ b/src/distributions/hierarchical_distribution.jl
@@ -147,6 +147,8 @@ ValueShapes.unshaped(d::HierarchicalDistribution) = UnshapedHDist(d)
 
 Base.length(ud::UnshapedHDist) = length(ud.shaped)
 
+eff_totalndof(d::UnshapedHDist) = eff_totalndof(d.shaped)
+
 Base.eltype(ud::UnshapedHDist{VF,T}) where {VF,T} = T
 
 
@@ -187,7 +189,7 @@ end
 =#
 
 function _hd_split(ud::UnshapedHDist, x::AbstractVector{<:Real})
-    @argcheck length(ud) == length(eachindex(x))
+    @argcheck eff_totalndof(ud) == length(eachindex(x))
     np = length(_hd_pridist(ud))
     idxs = eachindex(x)
     idxs_primary = first(idxs):(first(idxs) + np - 1)

--- a/src/transforms/distribution_transform.jl
+++ b/src/transforms/distribution_transform.jl
@@ -684,7 +684,7 @@ function apply_dist_trafo(trg_d::StdMvDist, src_d::HierarchicalDistribution, src
 end
 
 function apply_dist_trafo(trg_d::UnshapedHDist, src_d::StdMvDist, src_v::AbstractVector{<:Real})
-    src_v_primary, src_v_secondary = _hd_split(trg_d, src_v)
+    src_v_primary, src_v_secondary = _hd_split_efftotalndof(trg_d, src_v)
     src_d_primary = typeof(src_d)(length(eachindex(src_v_primary)))
     src_d_secondary = typeof(src_d)(length(eachindex(src_v_secondary)))
     trg_v_primary = apply_dist_trafo(_hd_pridist(trg_d), src_d_primary, src_v_primary)


### PR DESCRIPTION
Only checked the transform in #415 , so now reenable functionality to draw random sample from HierarchicalDistributions / anything calling _hd_split with eff_totalndof ≠ length in primary_dist.
No guarantees that there are some calls remaining which should rather work on newly introduced _hd_split_efftotalndof

```
using BAT
using ValueShapes
using Distributions
using InverseFunctions

d = HierarchicalDistribution(NamedTupleDist(
       a=truncated(Logistic(),0,Inf),
)) do v
       NamedTupleDist(
             b=Dirichlet(10,1/v.a),
       )
end

trafo = BAT.DistributionTransform(Normal,d)
inverse(trafo)(rand(Normal(), BAT.eff_totalndof(d))

rand(d)
rand(unshaped(d))
trafo(rand(d))

```