### PR TITLE
Fix InitFromSamples under transformations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BAT"
 uuid = "c0cd4b16-88b7-57fa-983b-ab80aecada7e"
-version = "3.3.1"
+version = "3.3.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/initvals/initvals.jl
+++ b/src/initvals/initvals.jl
@@ -167,3 +167,10 @@ function apply_trafo_to_init(trafo::Function, initalg::ExplicitInit)
     xs_tr = broadcast_trafo(trafo, initalg.xs)
     ExplicitInit(xs_tr)
 end
+
+function apply_trafo_to_init(f_transform::Function, initalg::InitFromSamples)
+    # ToDo: Pass context to apply_trafo_to_init
+    tmp_context = BATContext()
+    transformed_smpls = bat_transform_impl(f_transform, initalg.samples, SampleTransformation(), tmp_context).result
+    InitFromSamples(transformed_smpls)
+end


### PR DESCRIPTION
This works properly now:

```julia
using BAT

posterior = BAT.example_posterior()
smpls = bat_sample(posterior, MCMCSampling()).result

new_smpls = bat_sample(
    posterior,
    MCMCSampling(
        init = MCMCChainPoolInit(
            initval_alg = InitFromSamples(smpls)
        )
    )
).result
```