### PR TITLE
Refactor z position update in transformed MCMC

### DIFF
--- a/src/samplers/mcmc/mcmc_state.jl
+++ b/src/samplers/mcmc/mcmc_state.jl
@@ -294,32 +294,15 @@ function mcmc_update_z_position!!(mc_state::MCMCChainState)
     logd_z_current_new = logd_x_current - ladj_current
     logd_z_proposed_new = logd_x_proposed - ladj_proposed
 
-    sample_z_new = _new_similar_density_sample_vector(sample_z)
+    mc_state_new = deepcopy(mc_state)
 
-    sample_z_current_new = _new_similar_density_sample(sample_z[1], z_current_new[:], logd_z_current_new)
-    sample_z_proposed_new = _new_similar_density_sample(sample_z[2], z_proposed_new[:], logd_z_proposed_new)
-
-    push!(sample_z_new, sample_z_current_new, sample_z_proposed_new)
-
-    mc_state_new = @set mc_state.sample_z = sample_z_new
-
+    mc_state_new.sample_z.v[1] = vec(z_current_new)
+    mc_state_new.sample_z.v[2] = vec(z_proposed_new)
+    
+    mc_state_new.sample_z.logd[1] = logd_z_current_new
+    mc_state_new.sample_z.logd[2] = logd_z_proposed_new
+    
     return mc_state_new
-end
-
-# TODO: MD, Discuss wether these should be permanent functions
-function _new_similar_density_sample_vector(dsv_old::DensitySampleVector{P,T,W,R,Q}) where {
-    PT<:Real, P<:AbstractVector{PT}, T<:AbstractFloat, W<:Real, R, Q
-} 
-    return DensitySampleVector{P,T,W,R,Q}(undef, 0, length(dsv_old.v[1])) 
-end 
-
-function _new_similar_density_sample(sample_old::DensitySample{P,T,W,R,Q}, v_new::AbstractVector, logd_new::Real) where {
-    P<:AbstractVector{<:Real},T,W,R,Q
-}
-    info = sample_old.info
-    aux = sample_old.aux
-    P_new = typeof(v_new)
-    return DensitySample{P_new,T,W,R,Q}(v_new, convert(T, logd_new), one(W), info, aux)
 end
 
 # TODO: MD, Discuss: 

--- a/src/samplers/mcmc/mcmc_state.jl
+++ b/src/samplers/mcmc/mcmc_state.jl
@@ -278,29 +278,48 @@ function mcmc_update_z_position!!(mcmc_state::MCMCState)
     return mcmc_state_new
 end
 
-
 function mcmc_update_z_position!!(mc_state::MCMCChainState)
-
     f_transform = mc_state.f_transform
-    proposed_sample_x = proposed_sample(mc_state)
+    sample_z = mc_state.sample_z
+
     current_sample_x = current_sample(mc_state)
+    proposed_sample_x = proposed_sample(mc_state)
 
-    x_proposed, logd_x_proposed = proposed_sample_x.v, proposed_sample_x.logd 
     x_current, logd_x_current = current_sample_x.v, current_sample_x.logd
+    x_proposed, logd_x_proposed = proposed_sample_x.v, proposed_sample_x.logd 
 
-    z_proposed_new, ladj_proposed = with_logabsdet_jacobian(inverse(f_transform), vec(x_proposed))
-    z_current_new, ladj_current = with_logabsdet_jacobian(inverse(f_transform), vec(x_current))
+    z_current_new, ladj_current = with_logabsdet_jacobian(inverse(f_transform), x_current[:])
+    z_proposed_new, ladj_proposed = with_logabsdet_jacobian(inverse(f_transform), x_proposed[:])
 
-    logd_z_proposed_new = logd_x_proposed - ladj_proposed
     logd_z_current_new = logd_x_current - ladj_current
+    logd_z_proposed_new = logd_x_proposed - ladj_proposed
 
-    mc_state_tmp_1 = @set mc_state.sample_z.v[2] = vec(z_proposed_new)
-    mc_state_tmp_2 = @set mc_state_tmp_1.sample_z.logd[2] = logd_z_proposed_new
+    sample_z_new = _new_similar_density_sample_vector(sample_z)
 
-    mc_state_tmp_3 = @set mc_state_tmp_2.sample_z.v[1] = vec(z_current_new)
-    mc_state_new = @set mc_state_tmp_3.sample_z.logd[1] = logd_z_current_new
+    sample_z_current_new = _new_similar_density_sample(sample_z[1], z_current_new[:], logd_z_current_new)
+    sample_z_proposed_new = _new_similar_density_sample(sample_z[2], z_proposed_new[:], logd_z_proposed_new)
+
+    push!(sample_z_new, sample_z_current_new, sample_z_proposed_new)
+
+    mc_state_new = @set mc_state.sample_z = sample_z_new
 
     return mc_state_new
+end
+
+# TODO: MD, Discuss wether these should be permanent functions
+function _new_similar_density_sample_vector(dsv_old::DensitySampleVector{P,T,W,R,Q}) where {
+    PT<:Real, P<:AbstractVector{PT}, T<:AbstractFloat, W<:Real, R, Q
+} 
+    return DensitySampleVector{P,T,W,R,Q}(undef, 0, length(dsv_old.v[1])) 
+end 
+
+function _new_similar_density_sample(sample_old::DensitySample{P,T,W,R,Q}, v_new::AbstractVector, logd_new::Real) where {
+    P<:AbstractVector{<:Real},T,W,R,Q
+}
+    info = sample_old.info
+    aux = sample_old.aux
+    P_new = typeof(v_new)
+    return DensitySample{P_new,T,W,R,Q}(v_new, convert(T, logd_new), one(W), info, aux)
 end
 
 # TODO: MD, Discuss: 

--- a/test/optimization/test_mode_estimators.jl
+++ b/test/optimization/test_mode_estimators.jl
@@ -1,6 +1,7 @@
 using BAT
 using Test
 
+using AutoDiffOperators
 using LinearAlgebra, Distributions, StatsBase, ValueShapes, Random123, DensityInterface
 using UnPack, InverseFunctions
 import ForwardDiff
@@ -104,7 +105,7 @@ using Optim, OptimizationOptimJL
 
         context = BATContext(rng = Philox4x((0, 0)), ad = ADSelector(ForwardDiff))
         # result is not type-stable:
-        test_findmode(posterior, OptimizationAlg(optalg = Optimization.LBFGS(), trafo = DoNotTransform()), 0.01, context, inferred = false) 
+        test_findmode(posterior, OptimizationAlg(optalg = Optimization.LBFGS(), pretransform = DoNotTransform()), 0.01, context, inferred = false) 
     end
 
     @testset "Optimization.jl with custom options" begin # checks that options are correctly passed to Optimization.jl


### PR DESCRIPTION
This PR changes the way the `sample_z`object is updated during transformed mcmc. 
Now, a new `DensitySampleVector` with the updated z samples is created, which is then used in a new mcmc chain state via `@set` from `Accessors.jl`