### PR TITLE
Exclude plotting code from codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,4 @@
 # comment: false
+ignore:
+  - src/plotting
+  - ext/BATPlotsExt.jl


### PR DESCRIPTION
The code coverage might be underestimating how many lines of code are actually covered, because many of them are defining plot recipes.

This PR excludes these files from the `codecov` tests to provide a more realistic number on the code coverage.