### PR TITLE
Refactor mcmc_update_z_position!!()

### DIFF
--- a/src/samplers/mcmc/mcmc_state.jl
+++ b/src/samplers/mcmc/mcmc_state.jl
@@ -303,10 +303,10 @@ end
 function mcmc_update_z_position!!(mc_state::MCMCChainState)
     f_inv = inverse(mc_state.f_transform)
 
-    current_z_new = transform_samples(f_inv, mc_state.current.x)
-    proposed_z_new = transform_samples(f_inv, mc_state.proposed.x)
+    current_z_new::typeof(mc_state.current.z) = transform_samples(f_inv, mc_state.current.x)
+    proposed_z_new::typeof(mc_state.proposed.z) = transform_samples(f_inv, mc_state.proposed.x)
 
-    mc_state_new = @set mc_state.current.z = current_z_new
+    mc_state_new::typeof(mc_state) = @set mc_state.current.z = current_z_new
     mc_state_new = @set mc_state_new.proposed.z = proposed_z_new
     
     return mc_state_new


### PR DESCRIPTION
This removes a redundant call of `deepcopy()` which was bad for performance, and also cleans up the transformation of the samples by calling the BAT function `transform_samples()`