### PR TITLE
Store Optim results unwrapped in maximize_density results

### DIFF
--- a/ext/BATOptimExt.jl
+++ b/ext/BATOptimExt.jl
@@ -36,16 +36,17 @@ function BAT.maximize_density(f_logdensity, x_init::AbstractVector{<:Real}, algo
     f = fchain(f_logdensity, -)
     opts = convert_options(algorithm)
     optim_result = _optim_minimize(f, x_init, algorithm.optalg, opts, context)
-    r_optim = Optim.MaximizationWrapper(optim_result)
 
     # ToDo: Re-enable trace, make it type stable:
     #dummy_f_x = f(x_init) # ToDo: Avoid recomputation
     #trace_trafo = StructArray(;_neg_opt_trace(optim_result, x_init, dummy_f_x) ...)
 
-    ret_a = (result = Optim.minimizer(r_optim.res),)
+    ret_a = (result = Optim.minimizer(optim_result),)
     # Abstractly typed info field keeps the return type inferrable despite
-    # the type-unstable Optim result:
-    ret_b = @NamedTuple{info::Optim.MaximizationWrapper}((r_optim,))
+    # the type-unstable Optim result. Stored unwrapped: displaying an
+    # Optim.MaximizationWrapper is broken in Optim v1 (missing accessor
+    # forwarding in its show method):
+    ret_b = @NamedTuple{info::Optim.OptimizationResults}((optim_result,))
     return merge(ret_a, ret_b)
 end
 

--- a/test/optimization/test_mode_estimators.jl
+++ b/test/optimization/test_mode_estimators.jl
@@ -129,10 +129,10 @@ using Optim, OptimizationOptimJL, OptimizationLBFGSB
         optimizer = OptimAlg(optalg = NelderMead(), pretransform = DoNotTransform(), maxiters=20, maxtime=30, reltol=0.2, kwargs=(f_calls_limit=25,))
         
         result = bat_findmode(posterior, optimizer, context)
-        @test result.info.res.iterations <= 20
-        @test result.info.res.time_limit == 30
-        @test result.info.res.f_reltol == 0.2
-        @test result.info.res.f_calls <= 26
+        @test result.info.iterations <= 20
+        @test result.info.time_limit == 30
+        @test result.info.f_reltol == 0.2
+        @test result.info.f_calls <= 26
 
     end
 


### PR DESCRIPTION
Displaying the result of `bat_findmode`/`bat_bgml` with an `OptimAlg` throws on Optim v1:

```
MethodError: no method matching g_abstol(::Optim.MaximizationWrapper{...})
```

`Optim.MaximizationWrapper`'s `show` method in Optim v1 uses accessors (e.g. `g_abstol`) that are not forwarded to the wrapped result (fixed in Optim v2, but environments constrained to NLSolversBase v7 resolve Optim v1.13). Since the wrapper is only stored for diagnostics, store the raw `Optim.OptimizationResults` in the `info` field instead — displayable on both Optim majors. The `result` field is unaffected; the abstractly-typed `info` field trick for return-type inferrability is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)