### PR TITLE
Fix logarithmic-weight resampling

### DIFF
--- a/src/samplers/bat_sample.jl
+++ b/src/samplers/bat_sample.jl
@@ -108,7 +108,13 @@ function bat_sample_impl(smpls::DensitySampleVector, algorithm::RandResampling, 
     resampled_idxs = _rand_resampling_indices(rng, orig_idxs, smpls.weight, n)
 
     samples = smpls[resampled_idxs]
-    samples.weight .= 1
+    samples = DensitySampleVector((
+        samples.v,
+        samples.logd,
+        ones(eltype(samples.weight), length(samples)),
+        samples.info,
+        samples.aux,
+    ))
     (result = samples,)
 end
 

--- a/src/samplers/bat_sample.jl
+++ b/src/samplers/bat_sample.jl
@@ -102,7 +102,9 @@ end
 function bat_sample_impl(smpls::DensitySampleVector, algorithm::RandResampling, context::BATContext)
     n = algorithm.nsamples
     orig_idxs = eachindex(smpls)
-    weights = FrequencyWeights(float(smpls.weight))
+    scaled_weights = log.(smpls.weight)
+    scaled_weights .= exp.(scaled_weights .- maximum(scaled_weights))
+    weights = FrequencyWeights(scaled_weights)
     # Always generate resampled_idxs on CPU for now:
     rng = get_rng(context)
     resampled_idxs = sample(rng, orig_idxs, weights, n, replace=true, ordered=false)

--- a/src/samplers/bat_sample.jl
+++ b/src/samplers/bat_sample.jl
@@ -102,8 +102,9 @@ end
 function bat_sample_impl(smpls::DensitySampleVector, algorithm::RandResampling, context::BATContext)
     n = algorithm.nsamples
     orig_idxs = eachindex(smpls)
-    scaled_weights = log.(smpls.weight)
-    scaled_weights .= exp.(scaled_weights .- maximum(scaled_weights))
+    isempty(smpls) && iszero(n) && return (result = smpls[Int[]],)
+    logweights = log.(smpls.weight)
+    scaled_weights = exp.(logweights .- maximum(logweights))
     weights = FrequencyWeights(scaled_weights)
     # Always generate resampled_idxs on CPU for now:
     rng = get_rng(context)

--- a/src/samplers/bat_sample.jl
+++ b/src/samplers/bat_sample.jl
@@ -102,17 +102,25 @@ end
 function bat_sample_impl(smpls::DensitySampleVector, algorithm::RandResampling, context::BATContext)
     n = algorithm.nsamples
     orig_idxs = eachindex(smpls)
-    isempty(smpls) && iszero(n) && return (result = smpls[Int[]],)
-    logweights = log.(smpls.weight)
-    scaled_weights = exp.(logweights .- maximum(logweights))
-    weights = FrequencyWeights(scaled_weights)
+    iszero(n) && return (result = smpls[Int[]],)
     # Always generate resampled_idxs on CPU for now:
     rng = get_rng(context)
-    resampled_idxs = sample(rng, orig_idxs, weights, n, replace=true, ordered=false)
+    resampled_idxs = _rand_resampling_indices(rng, orig_idxs, smpls.weight, n)
 
     samples = smpls[resampled_idxs]
     samples.weight .= 1
     (result = samples,)
+end
+
+function _rand_resampling_indices(rng, indices, weights::AbstractVector{<:Real}, n::Integer)
+    sample(rng, indices, FrequencyWeights(float(weights)), n, replace=true, ordered=false)
+end
+
+function _rand_resampling_indices(rng, indices, weights::AbstractVector{<:ULogarithmic}, n::Integer)
+    log_cumweights = accumulate(_logaddexp, log.(weights))
+    log_total = last(log_cumweights)
+    isfinite(log_total) || throw(ArgumentError("Weights must sum to a finite positive value"))
+    [indices[searchsortedfirst(log_cumweights, log(rand(rng)) + log_total)] for _ in 1:n]
 end
 
 

--- a/test/samplers/test_bat_sample.jl
+++ b/test/samplers/test_bat_sample.jl
@@ -59,6 +59,9 @@ using StaticArrays: SVector
         empty_samples = DensitySampleVector(Vector{Vector{Float64}}(), Float64[])
         @test isempty(bat_sample(empty_samples, RandResampling(nsamples = 0), context).result)
 
+        zero_weight_samples = DensitySampleVector([[1.0], [2.0]], zeros(2), weight = zeros(2))
+        @test isempty(bat_sample(zero_weight_samples, RandResampling(nsamples = 0), context).result)
+
         n = 10^4
         logweights = -1000.0 .- (0:49)
         weighted_samples = DensitySampleVector(

--- a/test/samplers/test_bat_sample.jl
+++ b/test/samplers/test_bat_sample.jl
@@ -6,6 +6,7 @@ using Test
 using Random, Distributions, StatsBase
 using LogarithmicNumbers: ULogarithmic
 using StableRNGs: StableRNG
+using StaticArrays: SVector
 
 
 @testset "bat_sample" begin
@@ -47,6 +48,16 @@ using StableRNGs: StableRNG
         @test sort(unique(samples_rdm.v)) == sort(result.v)#check it only samples from the 2-sample space
         # Means should agree up to the resampling noise, which scales with the spread of the base samples:
         @test isapprox(mean(samples_rdm), mean(result), atol = 0.01 * abs(result.v[1] - result.v[2]))
+
+        immutable_weighted_samples = DensitySampleVector(
+            [[1.0], [2.0]],
+            zeros(2),
+            weight = SVector(2.0, 2.0),
+        )
+        @test length(bat_sample(immutable_weighted_samples, RandResampling(nsamples = 1), context).result) == 1
+
+        empty_samples = DensitySampleVector(Vector{Vector{Float64}}(), Float64[])
+        @test isempty(bat_sample(empty_samples, RandResampling(nsamples = 0), context).result)
 
         n = 10^4
         logweights = -1000.0 .- (0:49)

--- a/test/samplers/test_bat_sample.jl
+++ b/test/samplers/test_bat_sample.jl
@@ -4,9 +4,9 @@ using BAT
 using Test
 
 using Random, Distributions, StatsBase
+using FillArrays: Fill
 using LogarithmicNumbers: ULogarithmic
 using StableRNGs: StableRNG
-using StaticArrays: SVector
 
 
 @testset "bat_sample" begin
@@ -52,7 +52,7 @@ using StaticArrays: SVector
         immutable_weighted_samples = DensitySampleVector(
             [[1.0], [2.0]],
             zeros(2),
-            weight = SVector(2.0, 2.0),
+            weight = Fill(2.0, 2),
         )
         @test length(bat_sample(immutable_weighted_samples, RandResampling(nsamples = 1), context).result) == 1
 

--- a/test/samplers/test_bat_sample.jl
+++ b/test/samplers/test_bat_sample.jl
@@ -4,6 +4,8 @@ using BAT
 using Test
 
 using Random, Distributions, StatsBase
+using LogarithmicNumbers: ULogarithmic
+using StableRNGs: StableRNG
 
 
 @testset "bat_sample" begin
@@ -45,6 +47,23 @@ using Random, Distributions, StatsBase
         @test sort(unique(samples_rdm.v)) == sort(result.v)#check it only samples from the 2-sample space
         # Means should agree up to the resampling noise, which scales with the spread of the base samples:
         @test isapprox(mean(samples_rdm), mean(result), atol = 0.01 * abs(result.v[1] - result.v[2]))
+
+        n = 10^4
+        logweights = -1000.0 .- (0:49)
+        weighted_samples = DensitySampleVector(
+            [[Float64(i)] for i in eachindex(logweights)],
+            zeros(length(logweights)),
+            weight = exp.(ULogarithmic, logweights),
+        )
+        resamples = bat_sample(
+            weighted_samples,
+            RandResampling(nsamples = n),
+            BATContext(rng = StableRNG(892374)),
+        ).result
+        expected_fraction = inv(sum(exp.(-(0:49))))
+
+        @test count(==(1.0), only.(resamples.v)) / n ≈ expected_fraction atol = 0.02
+        @test all(isone, resamples.weight)
     end
 
     @testset "OrderedResampling" begin #Creates new testset for OrderedResampling


### PR DESCRIPTION
Avoids underflow in `RandResampling` with `ULogarithmic` weights by sampling in log space. Preserves ordinary-weight behavior, zero-sample requests, and immutable weight storage. Adds regression tests.
