### PR TITLE
Fix bridge sampling with non-integer weights

### DIFF
--- a/src/integration/bridge_sampling_integration.jl
+++ b/src/integration/bridge_sampling_integration.jl
@@ -137,7 +137,7 @@ function bridge_sampling_integral(
     post_cov_pd = PDMat(cholesky(Positive, post_cov))
 
     proposal_measure = batmeasure(MvNormal(post_mean,post_cov_pd))
-    proposal_samples = bat_sample_impl(proposal_measure, IIDSampling(nsamples=Int(sum(second_batch.weight))), context).result
+    proposal_samples = bat_sample_impl(proposal_measure, IIDSampling(nsamples=round(Int, sum(second_batch.weight))), context).result
     proposal_measure = batmeasure(proposal_measure)
 
     bridge_sampling_integral(target_measure,second_batch,proposal_measure,proposal_samples,strict,ess_alg,context)

--- a/test/integration/test_bridge_sampling_integration.jl
+++ b/test/integration/test_bridge_sampling_integration.jl
@@ -29,6 +29,17 @@ using LinearAlgebra: Diagonal, ones
             @test sample_integral.err < err_max
         end
     end
+
+    @testset "non-integer weights" begin
+        dist = MvNormal(zeros(2), ones(2))
+        samples = bat_sample(dist, IIDSampling(nsamples=20), context).result
+        samples = DensitySampleVector(samples.v, samples.logd, weight=fill(0.75, length(samples)))
+        evaluated = EvaluatedMeasure(dist, samples=samples)
+
+        result = bat_integrate(evaluated, BridgeSampling(pretransform=DoNotTransform()), context).result
+        @test isfinite(result.val)
+    end
+
     test_integration(BridgeSampling(pretransform=DoNotTransform()), "funnel distribution", FunnelDistribution(), val_rtol = 15)
     #! ToDo: Fix this test, cause trouble on x86-32
     #test_integration(BridgeSampling(pretransform=DoNotTransform()), "multimodal student-t distribution", MultimodalStudentT(), val_rtol = 50)


### PR DESCRIPTION
Fixes #337.

Use the rounded total weight for the proposal sample count, matching the existing bridge-sampling count calculation.

Add a regression test for non-integer weights.