### PR TITLE
Handle single-chain MCMC convergence checks

### DIFF
--- a/src/samplers/mcmc/mcmc_sample.jl
+++ b/src/samplers/mcmc/mcmc_sample.jl
@@ -118,6 +118,10 @@ bat_default(
 ) = MCMCMultiCycleBurnin(nsteps_per_cycle = max(div(nsteps, 10), 2500))
 
 function bat_sample_impl(m::BATMeasure, samplingalg::TransformedMCMC, context::BATContext)
+    if samplingalg.nchains == 1 && samplingalg.convergence isa Union{GelmanRubinConvergence, BrooksGelmanConvergence}
+        throw(ArgumentError("$(nameof(typeof(samplingalg.convergence))) requires at least two chains. Use convergence = AssumeConvergence() to sample with one chain."))
+    end
+
     transformed_m, f_pretransform = transform_and_unshape(samplingalg.pretransform, m, context)
 
     mcmc_states, chain_outputs = mcmc_init!(

--- a/test/samplers/mcmc/test_mcmc_sample.jl
+++ b/test/samplers/mcmc/test_mcmc_sample.jl
@@ -35,6 +35,15 @@ using DensityInterface
     context = BATContext()
     @test gensamples(context) != gensamples(context)
     @test gensamples(deepcopy(context)) == gensamples(deepcopy(context))
+
+    @test_throws ArgumentError bat_sample(
+        Normal(),
+        TransformedMCMC(
+            nchains = 1,
+            init = MCMCChainPoolInit(nsteps_init = 1),
+            burnin = MCMCMultiCycleBurnin(max_ncycles = 0)
+        )
+    )
     
     @test BAT.sample_and_verify(Normal(), TransformedMCMC(pretransform = DoNotTransform(), nwalkers = nwalkers, nsteps = 10^4)).verified
 end


### PR DESCRIPTION
Fixes #336.

Reject Gelman-Rubin convergence checks for single-chain sampling and point users to `AssumeConvergence()`.

Add a regression test.
