### PR TITLE
Clamp uniform quantiles monotonically

### DIFF
--- a/src/transforms/distribution_transform.jl
+++ b/src/transforms/distribution_transform.jl
@@ -473,10 +473,10 @@ end
 
 std_dist_to(trg_d::Distribution{Univariate,Continuous}) = StandardUvUniform()
 
-function dist_trafo_impl(trg_d::Distribution{Univariate,Continuous}, ::StandardUvUniform, src_v::Real)
-    TV = float(typeof(src_v))
-    # Avoid src_v ≈ 0 and src_v ≈ 1 to avoid infinite variate values for target distributions with infinite support:
-    mod_src_v = ifelse(src_v ≈ 0, zero(TV) + eps(TV), ifelse(src_v ≈ 1, one(TV) - eps(TV), convert(TV, src_v)))
+function dist_trafo_impl(trg_d::Distribution{Univariate,Continuous}, ::StandardUvUniform, src_v::U) where {U<:Real}
+    R = float(U)
+    # Preserve finite quantiles and monotonicity at the endpoints.
+    mod_src_v = clamp(convert(R, src_v), eps(R), one(R) - eps(R))
     _eval_dist_trafo_func(_trafo_quantile, trg_d, mod_src_v)
 end
 

--- a/test/transforms/test_distribution_transform.jl
+++ b/test/transforms/test_distribution_transform.jl
@@ -96,6 +96,10 @@ using StableRNGs: StableRNG
     test_back_and_forth(stdmvuni2, stdmvnorm2)
     test_back_and_forth(stdmvnorm2, stdmvuni2)
 
+    p = Float32[0, eps(Float32) / 2, eps(Float32), 0.9999, 1]
+    f = BAT.DistributionTransform(Exponential(), BAT.StandardUvUniform{Float32}())
+    @test f.(p) == quantile.(Exponential(), clamp.(p, eps(Float32), 1 - eps(Float32)))
+
     test_back_and_forth(beta, stduvnorm)
     test_back_and_forth(gamma, stduvnorm)
 


### PR DESCRIPTION
Fixes #538.

Clamp StandardUvUniform inputs to the input type's floating-point interval [eps(R), 1 - eps(R)] before inverse-CDF evaluation. This keeps infinite-support quantiles finite and preserves monotonicity without coupling the transform to an AD package.

Main code: +4/-4.