### PR TITLE
Repair adaptive multi-proposal picking rules

### DIFF
--- a/src/samplers/mcmc/mcmc_tuning/mcmc_adaptive_multiprop_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_adaptive_multiprop_tuner.jl
@@ -254,8 +254,13 @@ function _tune_picking_rule(
 )
     p_tuned = copy(picking_rule.p)
     p_tuned[curr_idx] = acc_new
-    p_tuned .*= (1 - picking_socket) / sum(p_tuned)
-    p_tuned .+= picking_socket / N  
+    total = sum(p_tuned)
+    if iszero(total)
+        fill!(p_tuned, 1 / N)
+    else
+        p_tuned .*= (1 - picking_socket) / total
+        p_tuned .+= picking_socket / N
+    end
     return Categorical(p_tuned)
 end
 


### PR DESCRIPTION
Closes #534.

Handle zero-mass adaptive picking-rule updates without producing NaNs. Use uniform probabilities when replacing the active proposal weight leaves no mass.

The other adaptive multi-proposal tuner repairs from #534 are already on `main`.

Main code: +7/-2.