### PR TITLE
Allow multivariate proposal distributions in RandomWalk

### DIFF
--- a/src/samplers/mcmc/mh_sampler.jl
+++ b/src/samplers/mcmc/mh_sampler.jl
@@ -89,9 +89,6 @@ function _full_random_walk_proposal(m::BATDistMeasure, n_dims::Integer)
     return batmeasure(_full_random_walk_proposal(d, n_dims))
 end
 
-# A user-supplied full multivariate innovation distribution would need a
-# symmetry guarantee (the random-walk acceptance assumes a symmetric
-# proposal), which can't be checked generically:
 function _full_random_walk_proposal(d::Distribution{Multivariate,Continuous}, n_dims::Integer)
     @argcheck length(d) == n_dims
     return d

--- a/src/samplers/mcmc/mh_sampler.jl
+++ b/src/samplers/mcmc/mh_sampler.jl
@@ -93,9 +93,8 @@ end
 # symmetry guarantee (the random-walk acceptance assumes a symmetric
 # proposal), which can't be checked generically:
 function _full_random_walk_proposal(d::Distribution{Multivariate,Continuous}, n_dims::Integer)
-    throw(ArgumentError(
-        "RandomWalk doesn't support full multivariate proposal distributions yet, use a univariate distribution (like Normal or TDist) that sets the shape of the per-dimension innovations"
-    ))
+    @argcheck length(d) == n_dims
+    return d
 end
 
 function _full_random_walk_proposal(d::Normal, n_dims::Integer)


### PR DESCRIPTION
Fixes #549.

Accept dimension-matched multivariate distributions directly as `RandomWalk` proposals while preserving measure normalization.

Main code: +2/-6.