### PR TITLE
Fix FixedNBins marginal-mode dispatch

### DIFF
--- a/src/statistics/binning_rules.jl
+++ b/src/statistics/binning_rules.jl
@@ -45,7 +45,7 @@ $(TYPEDFIELDS)
 end
 export FixedNBins
 
-function _binning_rule_impl(algorithm::FixedNBins, n_samples, nd, v)
+function _get_bining_impl(algorithm::FixedNBins, n_samples, nd, v)
     algorithm.nbins
 end
 

--- a/test/optimization/test_binned_mode_estimator.jl
+++ b/test/optimization/test_binned_mode_estimator.jl
@@ -1,0 +1,8 @@
+using BAT
+using Test
+
+@test BAT.bat_marginalmode(
+    BAT.DensitySampleVector([[1.0], [2.0], [3.0], [4.0], [5.0]], zeros(5)),
+    BAT.BinnedModeEstimator(binning = BAT.FixedNBins(nbins = 2)),
+    BAT.BATContext(),
+).result == [3.0]

--- a/test/optimization/test_optimization.jl
+++ b/test/optimization/test_optimization.jl
@@ -4,4 +4,5 @@ using Test
 
 Test.@testset "optimization" begin
     include("test_mode_estimators.jl")
+    include("test_binned_mode_estimator.jl")
 end


### PR DESCRIPTION
Fixes #551.

Implement `FixedNBins` at the existing `_get_bining_impl` seam used by `_get_binedges`. The internal spelling remains unchanged to avoid unrelated churn.

Main code: +1/-1.
