### PR TITLE
Filter weighted samples before marginalization

### DIFF
--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -28,7 +28,7 @@ function MarginalDist(
     filter::Bool = false
 )
 
-    if filter
+    if filter && !isempty(samples) && !all(iszero, samples.weight)
         samples = BAT.drop_low_weight_samples(samples)
     end
 

--- a/src/plotting/MarginalDist.jl
+++ b/src/plotting/MarginalDist.jl
@@ -28,14 +28,14 @@ function MarginalDist(
     filter::Bool = false
 )
 
+    if filter
+        samples = BAT.drop_low_weight_samples(samples)
+    end
+
     marg_samples = bat_marginalize(samples, vsel).result
     vs = varshape(marg_samples)
     vs isa NamedTupleShape ? shapes = [getproperty(acc, :shape) for acc in vs._accessors] : shapes = [0,0]
     UV = (vs isa ArrayShape && vsel isa Integer) || (length(shapes) == 1 && (shapes[1] isa Union{ScalarShape, ConstValueShape} || getproperty(shapes[1], :dims) == (1,)))
-
-    if filter
-        marg_samples = BAT.drop_low_weight_samples(marg_samples)
-    end
 
     marg_samples = flatview(unshaped.(marg_samples).v)
     cols = Tuple(Vector.(eachrow(marg_samples)))

--- a/src/plotting/recipes_samples_2D.jl
+++ b/src/plotting/recipes_samples_2D.jl
@@ -51,8 +51,7 @@
         reshaped_samples,
         vsel,
         bins = bins,
-        closed = closed,
-        filter = filter
+        closed = closed
     )
 
     if seriestype == :scatter

--- a/test/plotting/test_MarginalDist.jl
+++ b/test/plotting/test_MarginalDist.jl
@@ -46,21 +46,11 @@ using BAT: MarginalDist, get_bin_centers, find_marginalmodes, asindex
         @test isapprox(mean(binned_2d), [0, 0], atol = 0.1)
 
         low_weight_samples = DensitySampleVector(
-            [[0.0, 0.0], [1.0e15, -1.0e15], [1.0, 1.5], [2.0, 3.0]],
-            zeros(4);
-            weight = [1.0, 1.0e-12, 2.0e-12, 1.0],
+            [[0.0], [1.0e15], [1.0], [2.0]], zeros(4);
+            weight = [1.0, 1.0e-6, 5.0e-6, 1.0],
         )
-        filtered_samples = BAT.drop_low_weight_samples(low_weight_samples)
-
-        filtered_1d = MarginalDist(low_weight_samples, 1; bins = 4, filter = true)
-        expected_1d = MarginalDist(filtered_samples, 1; bins = 4)
-        @test get_bin_centers(filtered_1d) == get_bin_centers(expected_1d)
-        @test maximum(abs, only(get_bin_centers(filtered_1d))) < 10
-
-        filtered_2d = MarginalDist(low_weight_samples, (1, 2); bins = (4, 4), filter = true)
-        expected_2d = MarginalDist(filtered_samples, (1, 2); bins = (4, 4))
-        @test get_bin_centers(filtered_2d) == get_bin_centers(expected_2d)
-        @test all(maximum(abs, centers) < 10 for centers in get_bin_centers(filtered_2d))
+        filtered = MarginalDist(low_weight_samples, 1; bins = 4, filter = true)
+        @test maximum(abs, only(get_bin_centers(filtered))) < 10
     end
 
     @testset "from distribution" begin

--- a/test/plotting/test_MarginalDist.jl
+++ b/test/plotting/test_MarginalDist.jl
@@ -44,6 +44,23 @@ using BAT: MarginalDist, get_bin_centers, find_marginalmodes, asindex
         binned_2d = marg_2d.dist isa BAT.ReshapedDist ? marg_2d.dist.dist : marg_2d.dist
         @test binned_2d isa MvBinnedDist
         @test isapprox(mean(binned_2d), [0, 0], atol = 0.1)
+
+        low_weight_samples = DensitySampleVector(
+            [[0.0, 0.0], [1.0e15, -1.0e15], [1.0, 1.5], [2.0, 3.0]],
+            zeros(4);
+            weight = [1.0, 1.0e-12, 2.0e-12, 1.0],
+        )
+        filtered_samples = BAT.drop_low_weight_samples(low_weight_samples)
+
+        filtered_1d = MarginalDist(low_weight_samples, 1; bins = 4, filter = true)
+        expected_1d = MarginalDist(filtered_samples, 1; bins = 4)
+        @test get_bin_centers(filtered_1d) == get_bin_centers(expected_1d)
+        @test maximum(abs, only(get_bin_centers(filtered_1d))) < 10
+
+        filtered_2d = MarginalDist(low_weight_samples, (1, 2); bins = (4, 4), filter = true)
+        expected_2d = MarginalDist(filtered_samples, (1, 2); bins = (4, 4))
+        @test get_bin_centers(filtered_2d) == get_bin_centers(expected_2d)
+        @test all(maximum(abs, centers) < 10 for centers in get_bin_centers(filtered_2d))
     end
 
     @testset "from distribution" begin


### PR DESCRIPTION
Fixes #552.

Filter original weighted samples before projection so retained values and weights remain aligned. The 2D recipe avoids a second filter; zero-total weights retain prior behavior.

Main code: +5/-6.
