### PR TITLE
Reject unsupported PolarShellDistribution dimensions

### DIFF
--- a/src/distributions/polar_shell_distribution.jl
+++ b/src/distributions/polar_shell_distribution.jl
@@ -37,6 +37,8 @@ function PolarShellDistribution(
     base_dist::Distributions.Distribution{Multivariate,Continuous} = MvNormal(Diagonal([1,1])),
     radial_dist::Distributions.Distribution{Univariate,Continuous} = Rayleigh()
 )
+    length(base_dist) == 2 || throw(ArgumentError("PolarShellDistribution requires a two-dimensional base distribution"))
+
     base_measure = batmeasure(base_dist)
     r_transform = BAT.DistributionTransform(radial_dist, truncated(Normal(), 0, Inf))
     shell_transform = ShellRTransform(r_transform)


### PR DESCRIPTION
Fixes #554.

Validate that the base distribution is two-dimensional at construction. Previously accepted 1D and 3D inputs now fail early with `ArgumentError`.

Main code: +2/-0.
