### PR TITLE
Handle empty and zero-weight density sample inputs

### DIFF
--- a/src/variates/density_sample.jl
+++ b/src/variates/density_sample.jl
@@ -436,7 +436,9 @@ samples with the lowest weight.
 """
 function drop_low_weight_samples(samples::DensitySampleVector, fraction::Real = 10^-5; threshold::Real=10^-2)
     W = float(samples.weight)
-    if minimum(W) / maximum(W) > threshold
+    if isempty(W) || all(iszero, W)
+        samples
+    elseif minimum(W) / maximum(W) > threshold
         samples
     else
         W_s = sort(W)


### PR DESCRIPTION
Fixes #555.

Return empty or all-zero sample vectors unchanged before weight normalization. Empty multiplicity conversion is already handled on `main`.

Main code: +3/-1.