### PR TITLE
Validate low-rank Fisher updates

### DIFF
--- a/src/samplers/adaptive_transform.jl
+++ b/src/samplers/adaptive_transform.jl
@@ -248,13 +248,26 @@ diagonal geometry is insufficient. Tuning selects those directions by an
 eigenvalue cutoff (see [`FisherTransformTuning`](@ref)), which
 regularizes the geometry estimate compared to a full triangular matrix.
 
-Applying the transformation costs O(rank * n_dims), and the geometry
-fitting is projected: it accumulates diagonal moments plus a bounded
-window of recent draws and solves the Fisher problem in the joint thin
-subspace of the window, so estimation memory and fitting cost are
-O(n_dims * window) plus small-matrix work - no dense moments or solves
-(the transform initialization from an approximate covariance is the one
-remaining dense step).
+Applying the transformation costs O(rank * n_dims). Initialization from
+an approximate covariance honors `cutoff` and `max_rank` and may use a
+dense decomposition.
+
+Dynamic Fisher tuning currently makes one rank-one correction attempt
+for at most 32 dimensions when `cutoff >= 1.5`. It fits from a fixed
+window and uses a guard followed by held-out validation. HMC keeps the
+diagonal kernel during both. MALA installs the candidate provisionally
+during its guard so it can retune and mix, then keeps it after acceptance
+or restores the diagonal transform after rejection. The correction must beat
+both the frozen diagonal base and its own diagonal projection. Each paired
+Fisher-loss comparison needs a positive one-sided 99% normal lower bound with
+at least 20 effective observations. This rejects purely diagonal updates
+without restricting the shape of a correlation direction. Other settings tune
+only the diagonal base.
+
+This is a conservative held-out heuristic, not a finite-sample error-rate
+guarantee. Its asymptotic interpretation assumes stationary, mixing validation
+chains, finite long-run paired-loss variance, and independent walkers.
+Heavy-tailed cases outside those assumptions have only empirical evidence.
 
 Constructors:
 
@@ -268,14 +281,14 @@ $(TYPEDFIELDS)
     "Transform initialization algorithm."
     init::I = PriorApproxTransformInit()
 
-    "Maximum rank of the non-diagonal correction, `0` means no explicit
-    cap. Note that the estimable rank is always bounded by the size of
-    the estimation window of recent draws (see `FisherTransformTuning`)."
+    "Maximum rank of the non-diagonal correction during initialization,
+    `0` means no explicit cap. Dynamic Fisher tuning currently attempts
+    one rank-one correction."
     max_rank::Int = 0
 
-    "Relative eigenvalue cutoff: only directions in which the estimated
-    geometry deviates from the diagonal base by a factor above `cutoff`
-    (or below its inverse) enter the low-rank correction."
+    "Relative eigenvalue cutoff used during initialization. Dynamic
+    Fisher tuning requires `cutoff >= 1.5` and uses its fixed validated
+    rank-one policy."
     cutoff::Float64 = 1.5
 end
 

--- a/src/samplers/mcmc/mcmc_algorithm.jl
+++ b/src/samplers/mcmc/mcmc_algorithm.jl
@@ -323,6 +323,8 @@ end
 # simply tracks them:
 transform_change_restarts_stepsize(::MCMCTransformTunerState) = true
 
+transform_tuning_pauses_proposal(::MCMCTransformTunerState) = false
+
 # Called by the tuning orchestration instead of mcmc_tune_proposal_post_step!!
 # when a transform tuner has installed a new transformation and its policy
 # requests step-size readaptation. The step statistic that crossed the
@@ -334,6 +336,14 @@ function mcmc_proposal_transform_committed!!(
 ) where CS<:MCMCIterator
     return proposal, tuner, chain_state
 end
+
+mcmc_proposal_transform_committed!!(
+    proposal::MCMCProposalState,
+    tuner::MCMCProposalTunerState,
+    chain_state::CS,
+    ::MCMCTransformTunerState,
+) where {CS<:MCMCIterator} =
+    mcmc_proposal_transform_committed!!(proposal, tuner, chain_state)
 
 
 function mcmc_trafo_tuning_init!! end

--- a/src/samplers/mcmc/mcmc_state.jl
+++ b/src/samplers/mcmc/mcmc_state.jl
@@ -525,6 +525,8 @@ function mcmc_tune_post_cycle!!(state::MCMCState, samples::AbstractVector{<:Dens
 end
 
 function mcmc_tune_post_step!!(state::MCMCState, proposal::MCMCProposalState, step_info::MCMCStepInfo)
+    proposal_tuning_was_paused =
+        transform_tuning_pauses_proposal(state.trafo_tuner_state)
     f_transform_tuned, trafo_tuner_state_new, chain_state_trafo_tuned = mcmc_tune_trafo_post_step!!(
         state.chain_state.f_transform,
         state.trafo_tuner_state,
@@ -554,8 +556,12 @@ function mcmc_tune_post_step!!(state::MCMCState, proposal::MCMCProposalState, st
         mcmc_proposal_transform_committed!!(
             proposal,
             state.proposal_tuner_state,
-            chain_state_trafo_tuned
+            chain_state_trafo_tuned,
+            trafo_tuner_state_new,
         )
+    elseif proposal_tuning_was_paused ||
+            transform_tuning_pauses_proposal(trafo_tuner_state_new)
+        proposal, state.proposal_tuner_state, chain_state_trafo_tuned
     else
         mcmc_tune_proposal_post_step!!(
             proposal,

--- a/src/samplers/mcmc/mcmc_tuning/mcmc_fisher_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_fisher_tuner.jl
@@ -12,17 +12,122 @@ struct DiagonalFisherEstimator end
 struct LowRankFisherEstimator
     cutoff::Float64
     max_rank::Int
-    window::Int
 end
 
-# Window of recent draws the low-rank correction is estimated from (the
-# diagonal base uses the full foreground-background history). The window
-# bounds the estimation memory and fitting cost to O(n_dims * window) and
-# the estimable correction rank to 2 * window:
-_lowrank_window(max_rank::Integer) = clamp(4 * max(max_rank, 8), 32, 128)
-
 LowRankFisherEstimator(cutoff::Real, max_rank::Integer) =
-    LowRankFisherEstimator(cutoff, max_rank, _lowrank_window(max_rank))
+    LowRankFisherEstimator(Float64(cutoff), Int(max_rank))
+
+const _LR_DYNAMIC_MAX_DIMS = 32
+
+@enum _LowRankPhase::UInt8 _LRWaiting _LRFit _LRGuard _LRValidate _LRFrozen
+
+mutable struct _XGFitBlock
+    X::Matrix{Float64}
+    G::Matrix{Float64}
+    nsteps::Int
+end
+
+struct _LowRankCandidate
+    lambda::Vector{Float64}
+    vectors::Matrix{Float64}
+    W::Matrix{Float64}
+    S::Symmetric{Float64,Matrix{Float64}}
+end
+
+mutable struct _LowRankCampaign
+    phase::_LowRankPhase
+    attempted::Bool
+    admitted::Bool
+    cycle_step::Int
+    fit_start::Int
+    fit_steps::Int
+    guard_steps::Int
+    validation_steps::Int
+    final_steps::Int
+    fit::_XGFitBlock
+    validation_loss::Matrix{Float64}
+    validation_offdiag_loss::Matrix{Float64}
+    baseline_dvec::Union{Nothing,Vector{Float64}}
+    baseline_mu::Union{Nothing,Vector{Float64}}
+    candidate::Union{Nothing,_LowRankCandidate}
+end
+
+function _LowRankCampaign(
+    n_dims::Integer,
+    max_nsteps::Integer,
+    n_walkers::Integer,
+    is_mala::Bool = false,
+)
+    n_dims <= _LR_DYNAMIC_MAX_DIMS || return nothing
+    n_dims > 0 || return nothing
+    n_walkers > 0 || return nothing
+
+    fit_steps = n_dims >= 16 ? max(2 * n_dims, 64) : 2 * n_dims
+    guard_steps = is_mala ? max(n_dims, 64) : n_dims
+    validation_steps = is_mala ? max(16 * n_dims, 512) : max(8 * n_dims, 256)
+    final_steps = max(100, ceil(Int, 0.15 * max_nsteps))
+    fit_start = floor(Int, (is_mala ? 0.20 : 0.30) * max_nsteps) + 1
+    decision_end = fit_start + fit_steps + guard_steps + validation_steps - 1
+    deadline = floor(Int, 0.85 * max_nsteps)
+
+    decision_end <= deadline || return nothing
+    max_nsteps - decision_end >= final_steps || return nothing
+
+    return _LowRankCampaign(
+        _LRWaiting, false, false, 0, fit_start, fit_steps, guard_steps,
+        validation_steps, final_steps,
+        _XGFitBlock(
+            zeros(n_dims, fit_steps * n_walkers),
+            zeros(n_dims, fit_steps * n_walkers),
+            0,
+        ),
+        zeros(n_walkers, validation_steps),
+        zeros(n_walkers, validation_steps),
+        nothing,
+        nothing,
+        nothing,
+    )
+end
+
+function _diagonal_lowrank_campaign(
+    n_dims::Integer,
+    max_nsteps::Integer,
+    n_walkers::Integer,
+)
+    freeze_step = floor(Int, 0.85 * max_nsteps)
+    return _LowRankCampaign(
+        _LRWaiting, false, false, 0, freeze_step + 1, 0, 0, 0,
+        max_nsteps - freeze_step,
+        _XGFitBlock(zeros(n_dims, 0), zeros(n_dims, 0), 0),
+        zeros(n_walkers, 0),
+        zeros(n_walkers, 0),
+        nothing,
+        nothing,
+        nothing,
+    )
+end
+
+function _advance_lowrank_campaign!(campaign::_LowRankCampaign, cycle_step::Integer)
+    campaign.attempted && return campaign
+    campaign.cycle_step = cycle_step
+    fit_end = campaign.fit_start + campaign.fit_steps - 1
+    guard_end = fit_end + campaign.guard_steps
+    validation_end = guard_end + campaign.validation_steps
+
+    if cycle_step < campaign.fit_start
+        campaign.phase = _LRWaiting
+    elseif cycle_step <= fit_end
+        campaign.phase = _LRFit
+    elseif cycle_step <= guard_end
+        campaign.phase = _LRGuard
+    elseif cycle_step <= validation_end
+        campaign.phase = _LRValidate
+    else
+        campaign.phase = _LRFrozen
+        campaign.attempted = true
+    end
+    return campaign
+end
 
 _fisher_estimator(at::AbstractAdaptiveTransform) = throw(ArgumentError(
     "FisherTransformTuning requires an affine adaptive space transformation (a subtype of BAT.AbstractAffineTransform, like TriangularAffineTransform), got $(nameof(typeof(at)))"
@@ -113,6 +218,10 @@ periodically forgotten). Transform updates follow the `schedule`; each
 committed transform triggers a fresh step-size search and a dual-averaging
 restart in the step-size adaptor (see [`BAT.StepSizeAdaptor`](@ref)).
 
+Fisher moment, fit, and validation state uses `Float64`. Inputs with other
+scalar types are promoted for this tuning path; it is not type-preserving
+arithmetic.
+
 Constructors:
 
 * ```$(FUNCTIONNAME)(; fields...)```
@@ -180,28 +289,8 @@ _new_moments(::DenseFisherEstimator, n_dims::Integer, stride::Integer = 1) =
 _new_moments(::DiagonalFisherEstimator, n_dims::Integer, stride::Integer = 1) =
     _XGMoments(0, zeros(n_dims), zeros(n_dims), zeros(n_dims), zeros(n_dims), _Lag1Stats(n_dims, stride))
 
-# Diagonal Welford moments plus a bounded ring window of recent raw draws
-# that the low-rank correction is estimated from - O(n_dims * window)
-# memory, no dense moment matrices:
-mutable struct _XGWindowMoments <: _AbstractXGMoments
-    n::Int
-    mean_x::Vector{Float64}
-    mean_g::Vector{Float64}
-    var_x::Vector{Float64}
-    var_g::Vector{Float64}
-    X_win::Matrix{Float64}
-    G_win::Matrix{Float64}
-    win_ptr::Int
-    win_count::Int
-    lag1::_Lag1Stats
-end
-
 _new_moments(est::LowRankFisherEstimator, n_dims::Integer, stride::Integer = 1) =
-    _XGWindowMoments(
-        0, zeros(n_dims), zeros(n_dims), zeros(n_dims), zeros(n_dims),
-        zeros(n_dims, est.window), zeros(n_dims, est.window), 0, 0,
-        _Lag1Stats(n_dims, stride)
-    )
+    _new_moments(DiagonalFisherEstimator(), n_dims, stride)
 
 _m2_update!(M2::Matrix{Float64}, d_pre, d_post) = (M2 .+= d_pre .* d_post')
 _m2_update!(M2::Vector{Float64}, d_pre, d_post) = (M2 .+= d_pre .* d_post)
@@ -218,26 +307,8 @@ function _moments_update!(acc::_XGMoments, x::AbstractVector{<:Real}, g::Abstrac
     return acc
 end
 
-function _moments_update!(acc::_XGWindowMoments, x::AbstractVector{<:Real}, g::AbstractVector{<:Real})
-    n = (acc.n += 1)
-    dx_pre = x .- acc.mean_x
-    acc.mean_x .+= dx_pre ./ n
-    _m2_update!(acc.var_x, dx_pre, x .- acc.mean_x)
-    dg_pre = g .- acc.mean_g
-    acc.mean_g .+= dg_pre ./ n
-    _m2_update!(acc.var_g, dg_pre, g .- acc.mean_g)
-    ptr = mod1(acc.win_ptr + 1, size(acc.X_win, 2))
-    acc.win_ptr = ptr
-    acc.win_count = min(acc.win_count + 1, size(acc.X_win, 2))
-    acc.X_win[:, ptr] .= x
-    acc.G_win[:, ptr] .= g
-    _lag1_update!(acc.lag1, x)
-    return acc
-end
-
 _diag_var_raw(acc::_XGMoments{Vector{Float64}}) = acc.M2_x ./ max(acc.n - 1, 1)
 _diag_var_raw(acc::_XGMoments{Matrix{Float64}}) = diag(acc.M2_x) ./ max(acc.n - 1, 1)
-_diag_var_raw(acc::_XGWindowMoments) = acc.var_x ./ max(acc.n - 1, 1)
 
 # First-order (AR(1)) effective observation count: raw counts overstate
 # the information in autocorrelated warmup draws, which would shrink the
@@ -253,7 +324,7 @@ function _effective_nobs(acc::_AbstractXGMoments)
 end
 
 
-mutable struct FisherTrafoTunerState{TU<:FisherTransformTuning,E,MO<:_AbstractXGMoments} <: MCMCTransformTunerState
+mutable struct FisherTrafoTunerState{TU<:FisherTransformTuning,E,MO<:_AbstractXGMoments,CS} <: MCMCTransformTunerState
     tuning::TU
     estimator::E
     n_dims::Int
@@ -268,10 +339,29 @@ mutable struct FisherTrafoTunerState{TU<:FisherTransformTuning,E,MO<:_AbstractXG
     # contaminated early draws:
     acc_a::MO
     acc_b::MO
-    # Pieces (dvec, λ, V) of the last committed low-rank geometry, for the
-    # structured drift metric (nothing before the first commit, and for
-    # the dense and diagonal estimators):
-    committed_lr::Union{Nothing,Tuple{Vector{Float64},Vector{Float64},Matrix{Float64}}}
+    # Last committed diagonal base for the low-rank path. The correction
+    # campaign has one decision and therefore needs no rolling baseline.
+    committed_diag::Union{Nothing,Vector{Float64}}
+    campaign::CS
+end
+
+function transform_tuning_pauses_proposal(tuner::FisherTrafoTunerState)
+    campaign = tuner.campaign
+    return !isnothing(campaign) && campaign.phase == _LRValidate
+end
+
+function mcmc_proposal_transform_committed!!(
+    proposal::MALAProposalState,
+    tuner::MALAStepSizeTunerState,
+    chain_state::MCMCChainState,
+    trafo_tuner::FisherTrafoTunerState,
+)
+    _reset_mala_stepsize_tuner!(tuner, chain_state)
+    campaign = trafo_tuner.campaign
+    if !isnothing(campaign) && campaign.phase in (_LRFit, _LRFrozen)
+        tuner.min_run_nobs = min(40, campaign.final_steps) * nwalkers(chain_state)
+    end
+    return proposal, tuner, chain_state
 end
 
 # Whether a proposal provides z-space log-density gradients in its
@@ -312,10 +402,13 @@ function _create_fisher_tuner_state(tuning::FisherTransformTuning, chain_state::
     n_walkers = nwalkers(chain_state)
     memory_length = sched.memory_length > 0 ? sched.memory_length : max(100, 4 * n_dims)
     min_observations = sched.min_observations > 0 ? sched.min_observations : max(20, 2 * n_dims)
-    FisherTrafoTunerState(
+    acc_a = _new_moments(estimator, n_dims, n_walkers)
+    acc_b = _new_moments(estimator, n_dims, n_walkers)
+    campaign_type = estimator isa LowRankFisherEstimator ?
+        Union{Nothing,_LowRankCampaign} : Nothing
+    FisherTrafoTunerState{typeof(tuning),typeof(estimator),typeof(acc_a),campaign_type}(
         tuning, estimator, n_dims, memory_length, min_observations, 0,
-        _new_moments(estimator, n_dims, n_walkers), _new_moments(estimator, n_dims, n_walkers),
-        nothing
+        acc_a, acc_b, nothing, nothing
     )
 end
 
@@ -328,9 +421,44 @@ function mcmc_trafo_tuning_init!!(
     return nothing
 end
 
-# No mcmc_trafo_tuning_reinit!! specialization: estimation continues
-# seamlessly across burn-in cycles (the generic fallback is a no-op).
+function mcmc_trafo_tuning_reinit!!(
+    tuner_state::FisherTrafoTunerState,
+    chain_state::MCMCChainState,
+    max_nsteps::Integer,
+)
+    est = tuner_state.estimator
+    if est isa LowRankFisherEstimator
+        dynamic_eligible =
+            est.cutoff >= 1.5 && tuner_state.n_dims <= _LR_DYNAMIC_MAX_DIMS
+        campaign = tuner_state.campaign
+        retryable = isnothing(campaign) ||
+            (dynamic_eligible && campaign.fit_steps == 0)
+        retryable || return nothing
 
+        n_walkers = nwalkers(chain_state)
+        campaign = if !dynamic_eligible
+            _diagonal_lowrank_campaign(tuner_state.n_dims, max_nsteps, n_walkers)
+        else
+            candidate = _LowRankCampaign(
+                tuner_state.n_dims,
+                max_nsteps,
+                n_walkers,
+                get_active_proposal(chain_state.proposal) isa MALAProposalState,
+            )
+            isnothing(candidate) && !isnothing(campaign) && return nothing
+            something(
+                candidate,
+                _diagonal_lowrank_campaign(
+                    tuner_state.n_dims,
+                    max_nsteps,
+                    n_walkers,
+                ),
+            )
+        end
+        tuner_state.campaign = campaign
+    end
+    return nothing
+end
 
 # The regularization strength is relative to the mean variance scale of
 # each moment matrix, keeping the learned geometry equivariant under a
@@ -362,7 +490,7 @@ function _fisher_geometry(::DenseFisherEstimator, acc::_XGMoments, γ::Real)
     return G, μ
 end
 
-function _fisher_geometry(::DiagonalFisherEstimator, acc::_XGMoments, γ::Real)
+function _fisher_diagonal_geometry(acc::_XGMoments, γ::Real)
     n = acc.n
     var_x_raw = acc.M2_x ./ (n - 1)
     var_g_raw = acc.M2_g ./ (n - 1)
@@ -372,6 +500,12 @@ function _fisher_geometry(::DiagonalFisherEstimator, acc::_XGMoments, γ::Real)
     μ = acc.mean_x .+ g .* acc.mean_g
     return Diagonal(g), μ
 end
+
+_fisher_geometry(::DiagonalFisherEstimator, acc::_XGMoments, γ::Real) =
+    _fisher_diagonal_geometry(acc, γ)
+
+_fisher_geometry(::LowRankFisherEstimator, acc::_XGMoments, γ::Real) =
+    _fisher_diagonal_geometry(acc, γ)
 
 # Unique SPD solution G of the Riccati equation G C_g G = C_x, i.e. the
 # affine-invariant geometric mean of C_x and C_g⁻¹:
@@ -384,63 +518,230 @@ function _spd_riccati_solve(C_x::Symmetric, C_g::Symmetric)
     return Symmetric(S_isqrt * M_sqrt * S_isqrt)
 end
 
-# The projected low-rank geometry: a diagonal base from the full moment
-# history plus an eigenvalue-thresholded correction fitted in the joint
-# thin subspace spanned by the recent standardized position and score
-# window (Seyboldt et al. 2026). The window samples span the subspace
-# exactly, so the Fisher problem restricted to it is exact for the window
-# and the identity geometry is kept outside it - no dense moments and no
-# dense solves, everything is O(n_dims * window) plus small-matrix work.
-# Returns the geometry, the Fisher-optimal translation and the pieces
-# (dvec, λ, V) of the committed representation (for the structured drift):
-function _fisher_geometry_lr(est::LowRankFisherEstimator, acc::_XGWindowMoments, γ::Real)
-    n = acc.n
-    var_x_raw = acc.var_x ./ (n - 1)
-    var_g_raw = acc.var_g ./ (n - 1)
-    var_x = var_x_raw .+ _rel_regularization(γ, var_x_raw)
-    var_g = var_g_raw .+ _rel_regularization(γ, var_g_raw)
-
-    # Diagonal base fit and standardization (scores transform inversely
-    # to positions under x̃ = D^{-1/2} x):
-    dvec = sqrt.(var_x ./ var_g)
+# Fit one projected low-rank correction from an immutable block. The
+# diagonal base comes from the separate streaming estimator.
+function _fit_lowrank_candidate(
+    est::LowRankFisherEstimator,
+    dvec::AbstractVector,
+    Xfit::AbstractMatrix,
+    Gfit::AbstractMatrix,
+    γ::Real,
+)
+    m = size(Xfit, 2)
+    empty = _LowRankCandidate(
+        Float64[],
+        zeros(length(dvec), 0),
+        zeros(length(dvec), 0),
+        Symmetric(zeros(0, 0)),
+    )
+    size(Gfit) == size(Xfit) || throw(DimensionMismatch(
+        "position and score fit blocks must have the same shape",
+    ))
+    length(dvec) == size(Xfit, 1) || throw(DimensionMismatch(
+        "the diagonal base and fit block dimensions must match",
+    ))
+    m >= 8 || return empty
+    all(x -> isfinite(x) && x > 0, dvec) || return empty
+    all(isfinite, Xfit) && all(isfinite, Gfit) || return empty
     dsq = sqrt.(dvec)
 
-    m = acc.win_count
-    λ, V = if m >= 8
-        # The window is centered by its own means: centering by the
-        # longer-history means would add a mean-shift outer product to
-        # what must be a covariance estimate, turning warmup mean drift
-        # into a spurious correction direction. The longer-history means
-        # still serve the diagonal base and the translation:
-        X_w = view(acc.X_win, :, 1:m)
-        G_w = view(acc.G_win, :, 1:m)
-        Xc = (X_w .- (sum(X_w, dims = 2) ./ m)) ./ dsq
-        Gc = (G_w .- (sum(G_w, dims = 2) ./ m)) .* dsq
-        Q = Matrix(qr(hcat(Xc, Gc)).Q)
-        Px = Q' * Xc
-        Pg = Q' * Gc
-        Cx_q_raw = Symmetric(Px * Px' ./ (m - 1))
-        Cg_q_raw = Symmetric(Pg * Pg' ./ (m - 1))
-        Cx_q = Symmetric(Cx_q_raw + _rel_regularization(γ, Cx_q_raw) * I)
-        Cg_q = Symmetric(Cg_q_raw + _rel_regularization(γ, Cg_q_raw) * I)
-        Mq = _spd_riccati_solve(Cx_q, Cg_q)
-        E = eigen(Symmetric(Matrix(Mq)))
-        E.values, Q * E.vectors
-    else
-        # Not enough window data for a meaningful correction yet:
-        Float64[], zeros(length(dvec), 0)
-    end
-
-    # G = D^{1/2} (I + V_S (Λ_S - I) V_Sᵀ) D^{1/2} = D + W S Wᵀ:
-    W, S, λ_kept, V_kept = _lowrank_correction(dsq, λ, V, est.cutoff, est.max_rank)
-    G = woodbury_operator(Diagonal(dvec), W, S)
-    μ = acc.mean_x .+ G * acc.mean_g
-    return G, μ, (dvec, λ_kept, V_kept)
+    Xc = (Xfit .- (sum(Xfit, dims = 2) ./ m)) ./ dsq
+    Gc = (Gfit .- (sum(Gfit, dims = 2) ./ m)) .* dsq
+    all(isfinite, Xc) && all(isfinite, Gc) || return empty
+    Q = Matrix(qr(hcat(Xc, Gc)).Q)
+    Px = Q' * Xc
+    Pg = Q' * Gc
+    Cx_q_raw = Symmetric(Px * Px' ./ (m - 1))
+    Cg_q_raw = Symmetric(Pg * Pg' ./ (m - 1))
+    all(isfinite, Cx_q_raw) && all(isfinite, Cg_q_raw) || return empty
+    Cx_q = Symmetric(Cx_q_raw + _rel_regularization(γ, Cx_q_raw) * I)
+    Cg_q = Symmetric(Cg_q_raw + _rel_regularization(γ, Cg_q_raw) * I)
+    Mq = _spd_riccati_solve(Cx_q, Cg_q)
+    all(isfinite, Mq) || return empty
+    E = eigen(Symmetric(Matrix(Mq)))
+    λ, V = E.values, Q * E.vectors
+    W, S, λ_kept, V_kept =
+        _lowrank_correction(dsq, λ, V, est.cutoff, est.max_rank)
+    all(isfinite, λ_kept) && all(isfinite, V_kept) &&
+        all(isfinite, W) && all(isfinite, S) || return empty
+    return _LowRankCandidate(λ_kept, V_kept, W, S)
 end
 
-function _fisher_geometry(est::LowRankFisherEstimator, acc::_XGWindowMoments, γ::Real)
-    G, μ, _ = _fisher_geometry_lr(est, acc, γ)
-    return G, μ
+_valid_lowrank_baseline(dvec, mu) =
+    all(x -> isfinite(x) && x > 0, dvec) && all(isfinite, mu)
+
+_valid_lowrank_spectrum(candidate::_LowRankCandidate) =
+    length(candidate.lambda) == 1 &&
+    all(x -> isfinite(x) && 0.1 <= x <= 20, candidate.lambda)
+
+function _valid_lowrank_candidate(
+    candidate::_LowRankCandidate,
+    dvec,
+    mu,
+)
+    _valid_lowrank_baseline(dvec, mu) || return false
+    _valid_lowrank_spectrum(candidate) || return false
+    all(isfinite, candidate.vectors) || return false
+    all(isfinite, candidate.W) && all(isfinite, candidate.S) || return false
+    G = _lowrank_geometry(dvec, candidate)
+    G_dense = Symmetric(Matrix(G))
+    return all(isfinite, G_dense) && isposdef(G_dense)
+end
+
+_lowrank_geometry(dvec::AbstractVector, candidate::_LowRankCandidate) =
+    woodbury_operator(Diagonal(dvec), candidate.W, candidate.S)
+
+_lowrank_geometry_diagonal(dvec::AbstractVector, candidate::_LowRankCandidate) =
+    dvec .+ vec(sum((candidate.W * candidate.S) .* candidate.W, dims = 2))
+
+function _fisher_loss(A, mu, x, alpha)
+    fisher_residual = A' * alpha + A \ (x - mu)
+    return sum(abs2, fisher_residual)
+end
+
+function _invalid_lowrank_validation_stats()
+    return (
+        mean = NaN,
+        se = NaN,
+        se_within = NaN,
+        se_between = NaN,
+        n_eff = 0.0,
+        valid = false,
+    )
+end
+
+function _lowrank_validation_stats(delta::AbstractMatrix)
+    n_walkers, n_steps = size(delta)
+    n_walkers > 0 && n_steps > 1 || return _invalid_lowrank_validation_stats()
+    all(isfinite, delta) || return _invalid_lowrank_validation_stats()
+
+    walker_means = vec(mean(delta, dims = 2))
+    gamma0 = zeros(n_walkers)
+    sigma2_lr = zeros(n_walkers)
+    for walker in axes(delta, 1)
+        trace = view(delta, walker, :)
+        centered = trace .- walker_means[walker]
+        gamma0[walker] = sum(abs2, centered) / n_steps
+        gamma0[walker] > 0 || return _invalid_lowrank_validation_stats()
+        tau = tau_int_from_atc(fft_autocor(trace), GeyerAutocorLen())
+        isfinite(tau) || return _invalid_lowrank_validation_stats()
+        sigma2_lr[walker] = gamma0[walker] * max(tau, 1)
+    end
+
+    se_within2 = sum(sigma2_lr) / (n_walkers^2 * n_steps)
+    se_between2 = n_walkers >= 2 ? var(walker_means) / n_walkers : 0.0
+    se2 = max(se_within2, se_between2)
+    se2 > 0 && isfinite(se2) || return _invalid_lowrank_validation_stats()
+    n_eff = min(n_walkers * n_steps, mean(gamma0) / se2)
+    isfinite(n_eff) || return _invalid_lowrank_validation_stats()
+
+    return (
+        mean = mean(walker_means),
+        se = sqrt(se2),
+        se_within = sqrt(se_within2),
+        se_between = sqrt(se_between2),
+        n_eff,
+        valid = true,
+    )
+end
+
+function _lowrank_loss_improves(
+    delta::AbstractMatrix;
+    alpha::Real = 0.01,
+    min_n_eff::Real = 20,
+)
+    stats = _lowrank_validation_stats(delta)
+    stats.valid || return false
+    stats.n_eff >= min_n_eff || return false
+    z = quantile(Normal(), 1 - alpha)
+    return stats.mean - z * stats.se > 0
+end
+
+function _lowrank_validation_accepts(
+    candidate::_LowRankCandidate,
+    delta_baseline::AbstractMatrix,
+    delta_offdiag::AbstractMatrix;
+    kwargs...,
+)
+    _valid_lowrank_spectrum(candidate) || return false
+    return _lowrank_loss_improves(delta_baseline; kwargs...) &&
+        _lowrank_loss_improves(delta_offdiag; kwargs...)
+end
+
+function _lowrank_validation_factors(est, campaign::_LowRankCampaign)
+    G1 = _lowrank_geometry(campaign.baseline_dvec, campaign.candidate)
+    return (
+        _fisher_A(est, Diagonal(campaign.baseline_dvec)),
+        _fisher_A(est, G1),
+        _fisher_A(
+            est,
+            Diagonal(_lowrank_geometry_diagonal(
+                campaign.baseline_dvec,
+                campaign.candidate,
+            )),
+        ),
+    )
+end
+
+function _fit_lowrank_campaign!(
+    campaign::_LowRankCampaign,
+    est::LowRankFisherEstimator,
+    regularization::Real,
+    is_mala::Bool,
+    f_transform,
+)
+    candidate = _fit_lowrank_candidate(
+        LowRankFisherEstimator(est.cutoff, 1),
+        campaign.baseline_dvec,
+        campaign.fit.X,
+        campaign.fit.G,
+        regularization,
+    )
+    campaign.candidate = _valid_lowrank_candidate(
+        candidate,
+        campaign.baseline_dvec,
+        campaign.baseline_mu,
+    ) ? candidate : nothing
+    if is_mala && !isnothing(campaign.candidate)
+        G = _lowrank_geometry(campaign.baseline_dvec, campaign.candidate)
+        return MulAdd(
+            _fisher_A(est, G),
+            oftype(f_transform.b, campaign.baseline_mu),
+        )
+    end
+    return nothing
+end
+
+function _decide_lowrank_campaign(
+    campaign::_LowRankCampaign,
+    est::LowRankFisherEstimator,
+    is_mala::Bool,
+    f_transform,
+)
+    candidate = campaign.candidate
+    campaign.attempted = true
+    campaign.phase = _LRFrozen
+    admitted = !isnothing(candidate) && _lowrank_validation_accepts(
+        candidate,
+        campaign.validation_loss,
+        campaign.validation_offdiag_loss,
+    )
+    if admitted
+        campaign.admitted = true
+        if !is_mala
+            G = _lowrank_geometry(campaign.baseline_dvec, candidate)
+            return MulAdd(
+                _fisher_A(est, G),
+                oftype(f_transform.b, campaign.baseline_mu),
+            )
+        end
+    elseif is_mala && !isnothing(candidate)
+        return MulAdd(
+            _fisher_A(est, Diagonal(campaign.baseline_dvec)),
+            oftype(f_transform.b, campaign.baseline_mu),
+        )
+    end
+    return f_transform
 end
 
 _dense_spd(G::Symmetric) = G
@@ -451,6 +752,14 @@ _dense_spd(G) = Symmetric(Matrix(G))
 # estimator maintains:
 _fisher_A(::DenseFisherEstimator, G) = cholesky(Positive, Matrix(_dense_spd(G))).L
 _fisher_A(::DiagonalFisherEstimator, G::Diagonal) = Diagonal(sqrt.(G.diag))
+function _fisher_A(::LowRankFisherEstimator, G::Diagonal)
+    n_dims = length(G.diag)
+    return _lowrank_gram_factor(
+        G.diag,
+        zeros(n_dims, 0),
+        Symmetric(zeros(0, 0)),
+    )
+end
 _fisher_A(::LowRankFisherEstimator, G) = rowgram_factor(G)
 
 # Affine-invariant SPD distance between the installed geometry
@@ -465,50 +774,17 @@ function _transform_drift(A, G)
     return sqrt(sum(x -> abs2(log(max(x, tiny))), λ))
 end
 
-# Approximate affine-invariant drift between two diagonal-plus-low-rank
-# geometries G = D^{1/2} (I + V (Λ - I) Vᵀ) D^{1/2}, without materializing
-# dense matrices: the geometry pencil is evaluated exactly within the
-# joint correction span (both corrections live there), and by the pure
-# diagonal ratios on its complement (both geometries act diagonally
-# there); the in-span diagonal-only contribution is subtracted to avoid
-# double counting. Exact for pure diagonal changes and for pure
-# correction changes; approximate when both interact:
-function _lowrank_drift(
-    d_o::AbstractVector, λ_o::AbstractVector, V_o::AbstractMatrix,
-    d_n::AbstractVector, λ_n::AbstractVector, V_n::AbstractMatrix
-)
-    tiny = floatmin(Float64)
-    r = d_n ./ d_o
-    drift2 = sum(x -> abs2(log(max(x, tiny))), r)
-    isempty(λ_o) && isempty(λ_n) && return sqrt(drift2)
-
-    # Everything in the D_o-standardized frame, where the new correction
-    # directions transport as v -> R v with R = Diagonal(sqrt.(d_n ./ d_o)):
-    Rd = sqrt.(r)
-    U = Matrix(qr(hcat(Rd .* V_n, V_o)).Q)
-    q = size(U, 2)
-
-    UtVo = U' * V_o
-    B = Symmetric(Matrix(1.0 * I, q, q) + UtVo * Diagonal(λ_o .- 1) * UtVo')
-    RU = Rd .* U
-    RUtVn = RU' * V_n
-    C = Symmetric(RU' * RU + RUtVn * Diagonal(λ_n .- 1) * RUtVn')
-    σ = eigvals(C, B)
-    drift2 += sum(x -> abs2(log(max(x, tiny))), σ)
-
-    # In-span diagonal-only contribution, already counted in the ratio term:
-    τ = eigvals(Symmetric(Matrix(RU' * RU)))
-    drift2 -= sum(x -> abs2(log(max(x, tiny))), τ)
-
-    return sqrt(max(drift2, 0.0))
-end
-
 # The drift measurement itself is noisy; its statistical floor scales like
 # sqrt(2 n_dims / n_observations), with the effective (autocorrelation-
 # corrected) observation count, so the effective commit threshold stays
 # above it:
 function _effective_commit_threshold(sched::DriftCommitSchedule, n_dims::Integer, n_obs::Real)
     return sched.commit_threshold + 3 * sqrt(2 * n_dims / max(n_obs, 1))
+end
+
+function _diagonal_drift(old::AbstractVector, new::AbstractVector)
+    tiny = floatmin(Float64)
+    return sqrt(sum(x -> abs2(log(max(x, tiny))), new ./ old))
 end
 
 function mcmc_tune_trafo_post_step!!(
@@ -523,53 +799,136 @@ function mcmc_tune_trafo_post_step!!(
     z_grads = step_info.z_grads
     isnothing(z_grads) && return f_transform, tuner_state, chain_state
 
+    est = tuner_state.estimator
+    campaign = tuner_state.campaign
+    phase = nothing
+    if est isa LowRankFisherEstimator && !isnothing(campaign)
+        _advance_lowrank_campaign!(campaign, campaign.cycle_step + 1)
+        phase = campaign.phase
+    end
+
     A = f_transform.A
     xs_prop = proposed.x.v
     xs_curr = current.x.v
     accepted = chain_state.accepted
+    is_mala = proposal isa MALAProposalState
+    validation_idx = if phase == _LRValidate
+        validation_start = campaign.fit_start + campaign.fit_steps + campaign.guard_steps
+        campaign.cycle_step - validation_start + 1
+    else
+        0
+    end
+
+    validating = phase == _LRValidate && !isnothing(campaign.candidate)
+    validation_factors = validating ?
+        _lowrank_validation_factors(est, campaign) : (nothing, nothing, nothing)
+    baseline_A, candidate_A, candidate_diag_A = validation_factors
+
     for i in eachindex(xs_prop, z_grads)
         # Score transport into the fixed pre-adaptive space: for x = A z + μ
         # the pulled-back gradient is β = Aᵀ α, so α = A⁻ᵀ β:
         α = A' \ z_grads[i]
-        # The gradients refer to the selected (post-accept/reject) states,
-        # so the positions must too - on rejection the selected state is
-        # the current one, not the rejected proposal. A repeated state is
-        # a valid draw as well; accumulate in both memory blocks:
         x_i = accepted[i] ? xs_prop[i] : xs_curr[i]
-        _moments_update!(tuner_state.acc_a, x_i, α)
-        _moments_update!(tuner_state.acc_b, x_i, α)
+
+        if phase == _LRFit
+            column = campaign.fit.nsteps * length(xs_prop) + i
+            campaign.fit.X[:, column] .= x_i
+            campaign.fit.G[:, column] .= α
+        elseif validating
+            loss0 = _fisher_loss(baseline_A, campaign.baseline_mu, x_i, α)
+            loss1 = _fisher_loss(candidate_A, campaign.baseline_mu, x_i, α)
+            campaign.validation_loss[i, validation_idx] = loss0 - loss1
+            loss_diag = _fisher_loss(
+                candidate_diag_A,
+                campaign.baseline_mu,
+                x_i,
+                α,
+            )
+            campaign.validation_offdiag_loss[i, validation_idx] =
+                loss_diag - loss1
+        elseif isnothing(campaign) || phase == _LRWaiting
+            # The gradients refer to the selected states, so the positions
+            # must too. Repeated states remain valid observations.
+            _moments_update!(tuner_state.acc_a, x_i, α)
+            _moments_update!(tuner_state.acc_b, x_i, α)
+        end
+    end
+
+    provisional_transform = nothing
+    if phase == _LRFit
+        campaign.fit.nsteps += 1
+        if campaign.fit.nsteps == campaign.fit_steps
+            provisional_transform = _fit_lowrank_campaign!(
+                campaign,
+                est,
+                tuner_state.tuning.regularization,
+                is_mala,
+                f_transform,
+            )
+        end
     end
 
     tuner_state.nsteps += 1
-    if tuner_state.nsteps % tuner_state.memory_length == 0
+    accumulating = isnothing(campaign) || phase == _LRWaiting
+    if accumulating && tuner_state.nsteps % tuner_state.memory_length == 0
         tuner_state.acc_a = tuner_state.acc_b
         tuner_state.acc_b = _new_moments(tuner_state.estimator, tuner_state.n_dims, tuner_state.acc_b.lag1.stride)
+    end
+
+    if !isnothing(campaign) && phase == _LRWaiting &&
+            campaign.cycle_step == campaign.fit_start - 1
+        G, μ = _fisher_diagonal_geometry(
+            tuner_state.acc_a,
+            tuner_state.tuning.regularization,
+        )
+        if !_valid_lowrank_baseline(diag(G), μ)
+            campaign.phase = _LRFrozen
+            campaign.attempted = true
+            return f_transform, tuner_state, chain_state
+        end
+        campaign.baseline_dvec = copy(diag(G))
+        campaign.baseline_mu = copy(μ)
+        tuner_state.committed_diag = copy(diag(G))
+        A_new = _fisher_A(est, G)
+        return MulAdd(A_new, oftype(f_transform.b, μ)), tuner_state, chain_state
+    end
+
+    if !isnothing(provisional_transform)
+        return provisional_transform, tuner_state, chain_state
+    end
+
+    if phase == _LRValidate && validation_idx == campaign.validation_steps
+        f_transform_new = _decide_lowrank_campaign(
+            campaign,
+            est,
+            is_mala,
+            f_transform,
+        )
+        return f_transform_new, tuner_state, chain_state
+    end
+
+    if !isnothing(campaign) && phase != _LRWaiting
+        return f_transform, tuner_state, chain_state
     end
 
     sched = tuner_state.tuning.schedule
     acc = tuner_state.acc_a
     if tuner_state.nsteps % sched.check_interval == 0 && acc.n >= tuner_state.min_observations
-        est = tuner_state.estimator
         local G, μ, drift
-        lr_pieces = nothing
         if est isa LowRankFisherEstimator
-            G, μ, lr_pieces = _fisher_geometry_lr(est, acc, tuner_state.tuning.regularization)
-            # The installed initial geometry's pieces are unknown (the
-            # transform factor is an opaque operator), and a dense drift
-            # comparison against it would defeat the estimator's
-            # high-dimensional scaling. So the first statistically
-            # eligible estimate always commits, becoming the baseline;
-            # from then on the structured drift metric decides, and
-            # nothing on the low-rank path ever materializes a dense
-            # geometry:
-            drift = isnothing(tuner_state.committed_lr) ? oftype(sched.commit_threshold, Inf) :
-                _lowrank_drift(tuner_state.committed_lr..., lr_pieces...)
+            G, μ = _fisher_diagonal_geometry(acc, tuner_state.tuning.regularization)
+            dvec = diag(G)
+            drift = isnothing(tuner_state.committed_diag) ?
+                oftype(sched.commit_threshold, Inf) :
+                _diagonal_drift(tuner_state.committed_diag, dvec)
         else
             G, μ = _fisher_geometry(est, acc, tuner_state.tuning.regularization)
             drift = _transform_drift(A, G)
         end
         if drift > _effective_commit_threshold(sched, tuner_state.n_dims, _effective_nobs(acc))
-            tuner_state.committed_lr = lr_pieces
+            if est isa LowRankFisherEstimator
+                tuner_state.committed_diag = copy(diag(G))
+            end
             A_new = _fisher_A(est, G)
             b_new = oftype(f_transform.b, μ)
             return MulAdd(A_new, b_new), tuner_state, chain_state

--- a/src/samplers/mcmc/mcmc_tuning/mcmc_mala_stepsize_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_mala_stepsize_tuner.jl
@@ -14,6 +14,9 @@ mutable struct MALAStepSizeTunerState{T<:AbstractFloat} <: DualAveragingTunerSta
     log_mu::T
     log_stepsize_bar::T
     H_bar::T
+    run_nobs::Int
+    run_accept_sum::Float64
+    min_run_nobs::Int
 end
 
 function create_proposal_tuner_state(
@@ -25,11 +28,14 @@ function create_proposal_tuner_state(
     log_tau = log(proposal.τ)
     MALAStepSizeTunerState(
         tuning, 0, log_tau + log(oftype(log_tau, 10)),
-        zero(log_tau), zero(log_tau)
+        zero(log_tau), zero(log_tau), 0, 0.0, 50
     )
 end
 
-function _reset_mala_stepsize_tuner!(tuner::MALAStepSizeTunerState, chain_state::MCMCChainState)
+function _reset_mala_stepsize_tuner!(
+    tuner::MALAStepSizeTunerState,
+    chain_state::MCMCChainState,
+)
     proposal = get_active_proposal(chain_state.proposal)
     if proposal isa MALAProposalState
         _restart_dual_averaging!(tuner, proposal.τ)
@@ -38,6 +44,9 @@ function _reset_mala_stepsize_tuner!(tuner::MALAStepSizeTunerState, chain_state:
         tuner.log_stepsize_bar = 0
         tuner.H_bar = 0
     end
+    tuner.run_nobs = 0
+    tuner.run_accept_sum = zero(tuner.run_accept_sum)
+    tuner.min_run_nobs = 0
     return nothing
 end
 
@@ -58,7 +67,7 @@ function mcmc_proposal_transform_committed!!(
     tuner::MALAStepSizeTunerState,
     chain_state::MCMCChainState
 )
-    _restart_dual_averaging!(tuner, proposal.τ)
+    _reset_mala_stepsize_tuner!(tuner, chain_state)
     return proposal, tuner, chain_state
 end
 
@@ -68,13 +77,31 @@ function mcmc_tune_proposal_post_step!!(
     chain_state::MCMCChainState,
     step_info::MCMCStepInfo
 )
-    tau_new = _dual_averaging_step!(tuner, get_target_acceptance_ratio(proposal), mean(step_info.p_accept))
+    p_accept = step_info.p_accept
+    mean_accept = mean(p_accept)
+    tuner.run_nobs += length(p_accept)
+    tuner.run_accept_sum += length(p_accept) * mean_accept
+    tau_new = _dual_averaging_step!(
+        tuner, get_target_acceptance_ratio(proposal), mean_accept,
+    )
     proposal_new = if isfinite(tau_new)
         @set proposal.τ = oftype(proposal.τ, tau_new)
     else
         proposal
     end
     return proposal_new, tuner, chain_state
+end
+
+function get_tuning_success(
+    chain_state::MCMCChainState,
+    proposal::MALAProposalState,
+    tuner::MALAStepSizeTunerState,
+)
+    tuner.min_run_nobs == 0 && return get_tuning_success(chain_state, proposal)
+    tuner.run_nobs >= tuner.min_run_nobs || return false
+    acceptance = tuner.run_accept_sum / tuner.run_nobs
+    lower, upper = get_target_acceptance_int(proposal)
+    return lower <= acceptance <= upper
 end
 
 function mcmc_proposal_tuning_finalize!!(

--- a/test/samplers/mcmc/test_fisher_tuner.jl
+++ b/test/samplers/mcmc/test_fisher_tuner.jl
@@ -6,6 +6,7 @@ using Test
 using LinearAlgebra, Random, Statistics
 using Distributions, ValueShapes, DensityInterface, InverseFunctions
 using StableRNGs
+using Random123
 import ForwardDiff
 
 using Accessors: @set
@@ -19,6 +20,77 @@ using BAT: DenseFisherEstimator, DiagonalFisherEstimator, LowRankFisherEstimator
 # type, used to test the finalization contract:
 struct _TypeChangingTrafoFinalizer <: BAT.MCMCTransformTunerState end
 BAT.mcmc_trafo_tuning_finalize!!(f_transform::Function, tuner::_TypeChangingTrafoFinalizer, chain_state::BAT.MCMCIterator) = (identity, tuner, chain_state)
+
+function _fixed_lowrank_campaign(draw_score, d::Int, seed::Int)
+    rng = StableRNG(seed)
+    estimator = LowRankFisherEstimator(1.5, 1)
+    campaign = BAT._LowRankCampaign(d, 1000, 1)
+    acc = _new_moments(estimator, d, 1)
+    for _ in 1:(campaign.fit_start - 1)
+        x, score = draw_score(rng)
+        _moments_update!(acc, x, score)
+    end
+
+    G0, mu0 = BAT._fisher_diagonal_geometry(acc, 1e-5)
+    for k in axes(campaign.fit.X, 2)
+        x, score = draw_score(rng)
+        campaign.fit.X[:, k] .= x
+        campaign.fit.G[:, k] .= score
+    end
+    candidate = BAT._fit_lowrank_candidate(
+        estimator, diag(G0), campaign.fit.X, campaign.fit.G, 1e-5,
+    )
+    G1 = BAT._lowrank_geometry(diag(G0), candidate)
+    A0 = _fisher_A(estimator, G0)
+    A1 = _fisher_A(estimator, G1)
+    A1_diag = _fisher_A(
+        estimator,
+        Diagonal(BAT._lowrank_geometry_diagonal(diag(G0), candidate)),
+    )
+
+    for _ in 1:campaign.guard_steps
+        draw_score(rng)
+    end
+    delta_baseline = zeros(1, campaign.validation_steps)
+    delta_offdiag = zeros(1, campaign.validation_steps)
+    for k in axes(delta_baseline, 2)
+        x, score = draw_score(rng)
+        loss1 = BAT._fisher_loss(A1, mu0, x, score)
+        delta_baseline[k] = BAT._fisher_loss(A0, mu0, x, score) - loss1
+        delta_offdiag[k] = BAT._fisher_loss(A1_diag, mu0, x, score) - loss1
+    end
+    return (
+        accepted = BAT._lowrank_validation_accepts(
+            candidate,
+            delta_baseline,
+            delta_offdiag,
+        ),
+        G0,
+        G1,
+    )
+end
+
+function _lowrank_fisher_state(; cutoff = 1.5, max_nsteps = 1000, reinit = true)
+    d = 16
+    alg = TransformedMCMC(
+        proposal = HamiltonianMC(),
+        adaptive_transform = LowRankAffineTransform(cutoff = cutoff),
+        pretransform = DoNotTransform(),
+        nchains = 1,
+        nwalkers = 1,
+        nsteps = 100,
+    )
+    state = BAT.MCMCState(
+        alg,
+        batmeasure(product_distribution(fill(Normal(), d))),
+        1,
+        [zeros(d)],
+        BATContext(ad = ForwardDiff),
+    )
+    BAT.mcmc_tuning_init!!(state, max_nsteps)
+    reinit && BAT.mcmc_tuning_reinit!!(state, max_nsteps)
+    return state
+end
 
 @testset "fisher_tuner" begin
     rng = StableRNG(438621057)
@@ -113,35 +185,6 @@ BAT.mcmc_trafo_tuning_finalize!!(f_transform::Function, tuner::_TypeChangingTraf
         c2 = 4.0
         @test _transform_drift(A, Symmetric(c2 * Matrix(G))) ≈ log(c2) * sqrt(d)
 
-        # Structured drift between diagonal-plus-low-rank geometries:
-        dd = 6
-        d_o = collect(range(0.5, 2.0, length = dd))
-        v_dir = normalize(randn(rng, dd))
-        λ_o, V_o = [4.0], reshape(v_dir, dd, 1)
-        dense_of(dv, λ, V) = begin
-            dsq = sqrt.(dv)
-            Symmetric(Diagonal(dv) + (dsq .* V) * Diagonal(λ .- 1) * (dsq .* V)')
-        end
-        G_o = dense_of(d_o, λ_o, V_o)
-        A_o = LowerTriangular(Matrix(cholesky(G_o).L))
-
-        # Unchanged geometry has zero drift:
-        @test BAT._lowrank_drift(d_o, λ_o, V_o, d_o, λ_o, V_o) < 1e-8
-        # Pure correction change (same diagonal) is exact:
-        λ_n1 = [7.0]
-        @test BAT._lowrank_drift(d_o, λ_o, V_o, d_o, λ_n1, V_o) ≈
-            _transform_drift(A_o, dense_of(d_o, λ_n1, V_o)) atol = 1e-8
-        # Pure diagonal change without corrections is exact:
-        d_n = d_o .* range(1.5, 3.0, length = dd)
-        e0 = zeros(dd, 0)
-        @test BAT._lowrank_drift(d_o, Float64[], e0, d_n, Float64[], e0) ≈
-            _transform_drift(LowerTriangular(Matrix(cholesky(Symmetric(Matrix(Diagonal(d_o)))).L)), Symmetric(Matrix(Diagonal(d_n)))) atol = 1e-8
-        # Mixed changes are approximate but close to the dense metric:
-        v_dir2 = normalize(randn(rng, dd))
-        drift_approx = BAT._lowrank_drift(d_o, λ_o, V_o, d_n, [5.0], reshape(v_dir2, dd, 1))
-        drift_exact = _transform_drift(A_o, dense_of(d_n, [5.0], reshape(v_dir2, dd, 1)))
-        @test isapprox(drift_approx, drift_exact, rtol = 0.25)
-
         # Window translation invariance: the low-rank correction is a
         # covariance property, so a window whose mean drifted away from
         # the longer history must not produce a spurious correction
@@ -150,27 +193,53 @@ BAT.mcmc_trafo_tuning_finalize!!(f_transform::Function, tuner::_TypeChangingTraf
         est_tr = LowRankFisherEstimator(1.5, 0)
         acc_tr = _new_moments(est_tr, d_tr)
         Σ_tr = Diagonal([1.0, 2.0, 0.5, 1.5])
+        X_tr = zeros(d_tr, 32)
+        G_tr = zeros(d_tr, 32)
         for k in 1:500
             μ_k = k <= 460 ? zeros(d_tr) : fill(1.0, d_tr)
             x = μ_k .+ sqrt.(diag(Σ_tr)) .* randn(rng, d_tr)
             α = -Σ_tr \ (x .- μ_k)
             _moments_update!(acc_tr, x, α)
+            if k > 468
+                X_tr[:, k - 468] .= x
+                G_tr[:, k - 468] .= α
+            end
         end
-        G_tr, _ = _fisher_geometry(est_tr, acc_tr, 1e-5)
-        @test size(G_tr.B, 2) == 0
+        G_diag_tr, _ = BAT._fisher_diagonal_geometry(acc_tr, 1e-5)
+        candidate_tr = BAT._fit_lowrank_candidate(
+            est_tr,
+            diag(G_diag_tr),
+            X_tr,
+            G_tr,
+            1e-5,
+        )
+        @test isempty(candidate_tr.lambda)
 
         # Rank-deficient windows (repeated draws) must not create
         # spurious correction directions:
         acc_rd = _new_moments(est_tr, d_tr)
         xs_rd = [sqrt.(diag(Σ_tr)) .* randn(rng, d_tr) for _ in 1:8]
+        X_rd = zeros(d_tr, 32)
+        G_rd = zeros(d_tr, 32)
         for k in 1:200
             x = xs_rd[mod1(k, 8)]
             α = -Σ_tr \ x
             _moments_update!(acc_rd, x, α)
+            if k > 168
+                X_rd[:, k - 168] .= x
+                G_rd[:, k - 168] .= α
+            end
         end
-        G_rd, μ_rd = _fisher_geometry(est_tr, acc_rd, 1e-5)
+        G_diag_rd, μ_rd = BAT._fisher_diagonal_geometry(acc_rd, 1e-5)
+        candidate_rd = BAT._fit_lowrank_candidate(
+            est_tr,
+            diag(G_diag_rd),
+            X_rd,
+            G_rd,
+            1e-5,
+        )
         @test all(isfinite, μ_rd)
-        @test size(G_rd.B, 2) == 0
+        @test isempty(candidate_rd.lambda)
 
         # AR(1)-corrected effective observation count:
         acc_ar = _new_moments(DiagonalFisherEstimator(), 2)
@@ -199,13 +268,27 @@ BAT.mcmc_trafo_tuning_finalize!!(f_transform::Function, tuner::_TypeChangingTraf
         est = LowRankFisherEstimator(1.5, 0)
         acc = _new_moments(est, d)
         L = cholesky(Symmetric(Σ)).L
-        for _ in 1:10^4
+        Xfit = zeros(d, 2d)
+        Gfit = zeros(d, 2d)
+        for k in 1:10^4
             x = μ_true .+ L * randn(rng, d)
             α = -Σinv * (x .- μ_true)
             _moments_update!(acc, x, α)
+            if k <= 2d
+                Xfit[:, k] .= x
+                Gfit[:, k] .= α
+            end
         end
 
-        G, μ = _fisher_geometry(est, acc, 1e-5)
+        G_diag, μ = BAT._fisher_diagonal_geometry(acc, 1e-5)
+        candidate = BAT._fit_lowrank_candidate(
+            est,
+            diag(G_diag),
+            Xfit,
+            Gfit,
+            1e-5,
+        )
+        G = BAT._lowrank_geometry(diag(G_diag), candidate)
         @test opnorm(Matrix(G) - Σ) / opnorm(Σ) < 0.15
         @test isapprox(μ, μ_true, atol = 0.4)
 
@@ -215,8 +298,420 @@ BAT.mcmc_trafo_tuning_finalize!!(f_transform::Function, tuner::_TypeChangingTraf
 
         # A hard rank cap is respected:
         est_capped = LowRankFisherEstimator(1.5, 1)
-        G1, _ = _fisher_geometry(est_capped, acc, 1e-5)
-        @test size(G1.B, 2) <= 1  # W has at most max_rank columns in the Woodbury representation
+        candidate_capped = BAT._fit_lowrank_candidate(
+            est_capped,
+            diag(G_diag),
+            Xfit,
+            Gfit,
+            1e-5,
+        )
+        @test length(candidate_capped.lambda) <= 1
+    end
+
+    @testset "low-rank correction campaign schedule" begin
+        campaign = BAT._LowRankCampaign(16, 1000, 1)
+        @test campaign.phase == BAT._LRWaiting
+
+        BAT._advance_lowrank_campaign!(campaign, campaign.fit_start - 1)
+        @test campaign.phase == BAT._LRWaiting
+
+        BAT._advance_lowrank_campaign!(campaign, campaign.fit_start)
+        @test campaign.phase == BAT._LRFit
+        @test campaign.fit_steps == 64
+        @test campaign.guard_steps == 16
+        @test campaign.validation_steps == 256
+        @test campaign.final_steps >= 150
+
+        @test isnothing(BAT._LowRankCampaign(33, 1000, 1))
+        @test isnothing(BAT._LowRankCampaign(16, 150, 1))
+    end
+
+    @testset "low-rank correction campaign lifecycle" begin
+        state = _lowrank_fisher_state(reinit = false)
+        @test isnothing(state.trafo_tuner_state.campaign)
+
+        BAT.mcmc_tuning_reinit!!(state, 1000)
+        campaign = state.trafo_tuner_state.campaign
+        @test !isnothing(campaign)
+
+        BAT.mcmc_tuning_reinit!!(state, 2000)
+        @test state.trafo_tuner_state.campaign === campaign
+
+        state_low_cutoff = _lowrank_fisher_state(cutoff = 1.2)
+        diagonal_campaign = state_low_cutoff.trafo_tuner_state.campaign
+        @test !isnothing(diagonal_campaign)
+        @test diagonal_campaign.fit_steps == 0
+        BAT._advance_lowrank_campaign!(diagonal_campaign, 850)
+        @test diagonal_campaign.phase == BAT._LRWaiting
+        BAT._advance_lowrank_campaign!(diagonal_campaign, 851)
+        @test diagonal_campaign.phase == BAT._LRFrozen
+
+        short_state = _lowrank_fisher_state(max_nsteps = 150)
+        short_campaign = short_state.trafo_tuner_state.campaign
+        @test !isnothing(short_campaign)
+        @test short_campaign.fit_steps == 0
+        BAT._advance_lowrank_campaign!(short_campaign, 128)
+        @test short_campaign.phase == BAT._LRFrozen
+
+        BAT.mcmc_tuning_reinit!!(short_state, 150)
+        @test short_state.trafo_tuner_state.campaign === short_campaign
+
+        BAT.mcmc_tuning_reinit!!(short_state, 1000)
+        retry_campaign = short_state.trafo_tuner_state.campaign
+        @test retry_campaign !== short_campaign
+        @test retry_campaign.fit_steps == 64
+        @test retry_campaign.phase == BAT._LRWaiting
+    end
+
+    @testset "failed low-rank baseline stays frozen" begin
+        state = _lowrank_fisher_state()
+        tuner = state.trafo_tuner_state
+        campaign = tuner.campaign
+        tuner.acc_a.n = 2
+        fill!(tuner.acc_a.M2_x, NaN)
+        fill!(tuner.acc_a.M2_g, 1.0)
+        BAT._advance_lowrank_campaign!(campaign, campaign.fit_start - 2)
+
+        state = BAT.mcmc_step!!(state)
+        @test campaign.phase == BAT._LRFrozen
+        @test campaign.attempted
+        @test isnothing(campaign.baseline_dvec)
+
+        state = BAT.mcmc_step!!(state)
+        @test campaign.phase == BAT._LRFrozen
+        @test campaign.attempted
+        @test isnothing(campaign.baseline_dvec)
+    end
+
+    @testset "low-rank campaign pauses step-size tuning" begin
+        base = _lowrank_fisher_state()
+        campaign = base.trafo_tuner_state.campaign
+        fit_end = campaign.fit_start + campaign.fit_steps - 1
+        guard_end = fit_end + campaign.guard_steps
+        validation_end = guard_end + campaign.validation_steps
+
+        tuner_snapshot(state) = begin
+            tuner = state.proposal_tuner_state
+            proposal = BAT.get_active_proposal(state.chain_state.proposal)
+            (tuner.m, tuner.log_mu, tuner.log_stepsize_bar, tuner.H_bar,
+                tuner.run_nobs, tuner.run_accept_sum, tuner.run_accept_sqsum,
+                tuner.run_ndivergent, tuner.run_skip, proposal.step_size)
+        end
+
+        observed_pauses = Bool[]
+        expected_pauses = Bool[]
+        for (cycle_step, paused) in (
+            (0, false),
+            (campaign.fit_start - 1, false),
+            (fit_end, false),
+            (guard_end, true),
+            (validation_end - 1, true),
+        )
+            state = deepcopy(base)
+            BAT._advance_lowrank_campaign!(
+                state.trafo_tuner_state.campaign,
+                cycle_step,
+            )
+            before = tuner_snapshot(state)
+            state = BAT.mcmc_step!!(state)
+            after = tuner_snapshot(state)
+            push!(observed_pauses, after == before)
+            push!(expected_pauses, paused)
+        end
+        @test observed_pauses == expected_pauses
+
+        BAT._advance_lowrank_campaign!(campaign, validation_end + 1)
+        @test !BAT.transform_tuning_pauses_proposal(
+            base.trafo_tuner_state,
+        )
+    end
+
+    @testset "low-rank correction fit separation" begin
+        d = 16
+        gamma = 1e-5
+        est = LowRankFisherEstimator(1.5, 1)
+        acc_diag = _new_moments(DiagonalFisherEstimator(), d)
+        acc_lr = _new_moments(est, d)
+        rng_fit = StableRNG(91042)
+
+        for _ in 1:200
+            x = randn(rng_fit, d)
+            g = -x
+            _moments_update!(acc_diag, x, g)
+            _moments_update!(acc_lr, x, g)
+        end
+
+        G_diag, mu_diag = BAT._fisher_diagonal_geometry(acc_diag, gamma)
+        G_lr, mu_lr = BAT._fisher_diagonal_geometry(acc_lr, gamma)
+        @test diag(G_lr) ≈ diag(G_diag)
+        @test mu_lr ≈ mu_diag
+
+        u = normalize(ones(d))
+        Sigma = Symmetric(Matrix(I, d, d) + 16.0 * u * u')
+        Sigma_inv = inv(Sigma)
+        L = cholesky(Sigma).L
+        Xfit = reduce(hcat, (L * randn(rng_fit, d) for _ in 1:(2d)))
+        Gfit = reduce(hcat, (-Sigma_inv * x for x in eachcol(Xfit)))
+        dvec = fill(sqrt(17 / 8), d)
+
+        candidate = BAT._fit_lowrank_candidate(est, dvec, Xfit, Gfit, gamma)
+        @test length(candidate.lambda) == 1
+        G_candidate = BAT._lowrank_geometry(dvec, candidate)
+        @test opnorm(Matrix(G_candidate) - Sigma) / opnorm(Sigma) < 0.1
+        @test BAT._lowrank_geometry_diagonal(dvec, candidate) ≈
+            diag(Matrix(G_candidate))
+
+        axis_candidate = BAT._LowRankCandidate(
+            [2.0],
+            reshape([1.0; zeros(d - 1)], d, 1),
+            reshape([1.0; zeros(d - 1)], d, 1),
+            Symmetric(ones(1, 1)),
+        )
+        @test BAT._valid_lowrank_candidate(axis_candidate, ones(d), zeros(d))
+
+        hub_direction = normalize([0.8, 0.6, zeros(d - 2)...])
+        W_hub, S_hub, lambda_hub, vectors_hub = BAT._lowrank_correction(
+            ones(d),
+            [3.0],
+            reshape(hub_direction, d, 1),
+            1.5,
+            1,
+        )
+        hub_candidate = BAT._LowRankCandidate(
+            lambda_hub,
+            vectors_hub,
+            W_hub,
+            S_hub,
+        )
+        @test BAT._valid_lowrank_candidate(hub_candidate, ones(d), zeros(d))
+        @test BAT._valid_lowrank_candidate(candidate, dvec, zeros(d))
+
+        candidate_nonfinite = BAT._fit_lowrank_candidate(
+            est,
+            dvec,
+            fill(NaN, size(Xfit)),
+            Gfit,
+            gamma,
+        )
+        @test isempty(candidate_nonfinite.lambda)
+        candidate_bad_base = BAT._fit_lowrank_candidate(
+            est,
+            zeros(d),
+            Xfit,
+            Gfit,
+            gamma,
+        )
+        @test isempty(candidate_bad_base.lambda)
+    end
+
+    @testset "low-rank held-out admission" begin
+        d = 4
+        mu = collect(range(-0.4, 0.5, length = d))
+        x = [0.2, -1.1, 0.7, 1.4]
+        alpha = [-0.3, 0.8, -0.2, 0.5]
+        dvec = [0.7, 1.2, 2.0, 0.9]
+        A_diag = Diagonal(sqrt.(dvec))
+
+        loss_diag = BAT._fisher_loss(A_diag, mu, x, alpha)
+        residual = x - mu
+        loss_diag_dense = sum(abs2, A_diag' * alpha + A_diag \ residual)
+        @test loss_diag ≈ loss_diag_dense
+
+        direction = normalize([1.0, -2.0, 0.5, 1.5])
+        lambda = [3.0]
+        W, S, lambda_kept, vectors_kept = BAT._lowrank_correction(
+            sqrt.(dvec),
+            lambda,
+            reshape(direction, d, 1),
+            1.5,
+            1,
+        )
+        candidate = BAT._LowRankCandidate(
+            lambda_kept,
+            vectors_kept,
+            W,
+            S,
+        )
+        G_lr = BAT._lowrank_geometry(dvec, candidate)
+        A_lr = _fisher_A(LowRankFisherEstimator(1.5, 1), G_lr)
+        loss_lr = BAT._fisher_loss(A_lr, mu, x, alpha)
+        A_lr_dense = Matrix(A_lr)
+        loss_lr_dense = sum(abs2, A_lr_dense' * alpha +
+            A_lr_dense \ residual)
+        @test loss_lr ≈ loss_lr_dense
+
+        candidate0 = BAT._LowRankCandidate(
+            Float64[],
+            zeros(d, 0),
+            zeros(d, 0),
+            Symmetric(zeros(0, 0)),
+        )
+        @test BAT._fisher_loss(
+            _fisher_A(
+                LowRankFisherEstimator(1.5, 1),
+                BAT._lowrank_geometry(dvec, candidate0),
+            ),
+            mu,
+            x,
+            alpha,
+        ) ≈ loss_diag
+
+        t = collect(1:256)
+        positive = reshape(1 .+ 0.1 .* sin.(t), 1, :)
+        negative = -positive
+        nonfinite = copy(positive)
+        nonfinite[1, 20] = NaN
+        short = reshape(1 .+ 0.1 .* sin.(1:40), 1, :)
+        moderate = reshape(1 .+ 0.1 .* (-1.0).^(1:40), 1, :)
+
+        @test BAT._lowrank_validation_accepts(candidate, positive, positive)
+        candidate_15 = BAT._LowRankCandidate(
+            [15.0], candidate.vectors, candidate.W, candidate.S,
+        )
+        candidate_21 = BAT._LowRankCandidate(
+            [21.0], candidate.vectors, candidate.W, candidate.S,
+        )
+        @test BAT._lowrank_validation_accepts(candidate_15, positive, positive)
+        @test !BAT._lowrank_validation_accepts(candidate_21, positive, positive)
+        @test !BAT._lowrank_validation_accepts(candidate, negative, positive)
+        @test !BAT._lowrank_validation_accepts(candidate, positive, negative)
+        @test !BAT._lowrank_validation_accepts(candidate, nonfinite, positive)
+        @test !BAT._lowrank_validation_accepts(candidate, positive, nonfinite)
+        @test !BAT._lowrank_validation_accepts(
+            candidate,
+            ones(1, 256),
+            positive,
+        )
+        @test !BAT._lowrank_validation_accepts(candidate, short, positive)
+        @test BAT._lowrank_validation_accepts(candidate, moderate, moderate)
+        @test !BAT._lowrank_validation_accepts(candidate0, positive, positive)
+        @test !BAT._lowrank_validation_accepts(
+            candidate,
+            positive,
+            zeros(size(positive)),
+        )
+
+        sparse_direction = normalize([0.8, 0.6, zeros(d - 2)...])
+        W_sparse, S_sparse, lambda_sparse, vectors_sparse =
+            BAT._lowrank_correction(
+                ones(d),
+                [3.0],
+                reshape(sparse_direction, d, 1),
+                1.5,
+                1,
+            )
+        sparse_candidate = BAT._LowRankCandidate(
+            lambda_sparse,
+            vectors_sparse,
+            W_sparse,
+            S_sparse,
+        )
+        G_sparse = BAT._lowrank_geometry(ones(d), sparse_candidate)
+        A_sparse = _fisher_A(LowRankFisherEstimator(1.5, 1), G_sparse)
+        A_sparse_diag = _fisher_A(
+            LowRankFisherEstimator(1.5, 1),
+            Diagonal(BAT._lowrank_geometry_diagonal(ones(d), sparse_candidate)),
+        )
+        sparse_target = MvNormal(zeros(d), Symmetric(Matrix(G_sparse)))
+        sparse_baseline_delta = zeros(1, 256)
+        sparse_offdiag_delta = similar(sparse_baseline_delta)
+        sparse_rng = StableRNG(826_564_004)
+        for k in axes(sparse_baseline_delta, 2)
+            x_sparse = rand(sparse_rng, sparse_target)
+            score_sparse = -(G_sparse \ x_sparse)
+            loss_sparse = BAT._fisher_loss(
+                A_sparse, zeros(d), x_sparse, score_sparse,
+            )
+            sparse_baseline_delta[k] = BAT._fisher_loss(
+                Diagonal(ones(d)), zeros(d), x_sparse, score_sparse,
+            ) - loss_sparse
+            sparse_offdiag_delta[k] = BAT._fisher_loss(
+                A_sparse_diag, zeros(d), x_sparse, score_sparse,
+            ) - loss_sparse
+        end
+        @test BAT._lowrank_validation_accepts(
+            sparse_candidate,
+            sparse_baseline_delta,
+            sparse_offdiag_delta,
+        )
+
+        disagreeing = vcat(
+            reshape(0.1 .* sin.(t), 1, :),
+            reshape(2 .+ 0.1 .* sin.(t), 1, :),
+        )
+        stats = BAT._lowrank_validation_stats(disagreeing)
+        @test stats.se == max(stats.se_within, stats.se_between)
+        @test stats.se_between > stats.se_within
+    end
+
+    @testset "low-rank null and power controls" begin
+        independent_draw_score(dist, d) = begin
+            nu = dist isa TDist ? first(Distributions.params(dist)) : NaN
+            score = dist isa TDist ?
+                (x -> -(nu + 1) * x / (nu + x^2)) :
+                dist isa Logistic ? (x -> -tanh(x / 2)) :
+                (x -> -sign(x))
+            rng -> begin
+                x = rand(rng, dist, d)
+                x, score.(x)
+            end
+        end
+
+        for dist in (TDist(5), TDist(10), Logistic(), Laplace()), d in (16, 32)
+            result = _fixed_lowrank_campaign(
+                independent_draw_score(dist, d), d, 101,
+            )
+            @test !result.accepted
+        end
+
+        d = 32
+        nu = 5.0
+        scale = sqrt((nu - 2) / nu)
+        u = normalize(ones(d))
+        Sigma = Symmetric(Matrix(I, d, d) + 16.0 * u * u')
+        L = cholesky(Sigma).L
+        draw_score = rng -> begin
+            y = scale .* rand(rng, TDist(nu), d)
+            score_y = @. -(nu + 1) * y / (nu * scale^2 + y^2)
+            L * y, L' \ score_y
+        end
+        result = _fixed_lowrank_campaign(draw_score, d, 101)
+        fisher_scale = inv(sqrt(nu * (nu + 1) / ((nu - 2) * (nu + 3))))
+        G_oracle = fisher_scale .* Sigma
+        baseline_error = BAT._transform_drift(
+            Diagonal(sqrt.(diag(result.G0))), G_oracle,
+        )
+        candidate_error = BAT._transform_drift(
+            BAT._fisher_A(LowRankFisherEstimator(1.5, 1), result.G1),
+            G_oracle,
+        )
+        @test result.accepted
+        @test candidate_error < 0.8 * baseline_error
+    end
+
+    @testset "low-rank product-t HMC lifecycle" begin
+        objective = product_distribution(fill(TDist(3), 32))
+        alg = TransformedMCMC(
+            proposal = HamiltonianMC(max_depth = 4),
+            adaptive_transform = LowRankAffineTransform(),
+            pretransform = DoNotTransform(),
+            nchains = 1,
+            nwalkers = 1,
+            nsteps = 20,
+            init = MCMCChainPoolInit(nsteps_init = 10),
+            burnin = MCMCMultiCycleBurnin(
+                nsteps_per_cycle = 1000,
+                max_ncycles = 1,
+                nsteps_final = 0,
+            ),
+            convergence = AssumeConvergence(),
+        )
+        result = evalmeasure(
+            batmeasure(objective),
+            alg,
+            BATContext(rng = Philox4x((42, 43)), ad = ForwardDiff),
+        )
+        @test only(BAT.samplegenof(result).chain_states).info.tuned
     end
 
     @testset "guards" begin

--- a/test/samplers/mcmc/test_mala.jl
+++ b/test/samplers/mcmc/test_mala.jl
@@ -6,6 +6,7 @@ using Test
 using LinearAlgebra, Random, Statistics
 using Distributions, ValueShapes, DensityInterface
 using StableRNGs
+using Random123
 import ForwardDiff
 
 using BAT: MALAProposal, StepSizeAdaptor, LowRankAffineTransform,
@@ -103,18 +104,142 @@ using BAT: MALAProposal, StepSizeAdaptor, LowRankAffineTransform,
     @testset "step scale adaptation" begin
         # Dual averaging moves τ against a persistent acceptance
         # imbalance:
-        tuner_lo = BAT.MALAStepSizeTunerState(StepSizeAdaptor(), 0, log(10 * 0.5), 0.0, 0.0)
+        tuner_lo = BAT.MALAStepSizeTunerState(StepSizeAdaptor(), 0, log(10 * 0.5), 0.0, 0.0, 0, 0.0, 50)
         τ = 0.5
         for _ in 1:200
             τ = BAT._dual_averaging_step!(tuner_lo, 0.574, 0.1)
         end
         @test τ < 0.5
 
-        tuner_hi = BAT.MALAStepSizeTunerState(StepSizeAdaptor(), 0, log(10 * 0.5), 0.0, 0.0)
+        tuner_hi = BAT.MALAStepSizeTunerState(StepSizeAdaptor(), 0, log(10 * 0.5), 0.0, 0.0, 0, 0.0, 50)
         τ = 0.5
         for _ in 1:200
             τ = BAT._dual_averaging_step!(tuner_hi, 0.574, 0.95)
         end
         @test τ > 0.5
+    end
+
+    @testset "provisional low-rank validation" begin
+        d = 16
+        u = normalize(ones(d))
+        objective = MvNormal(
+            zeros(d),
+            Symmetric(Matrix{Float64}(I, d, d) + 16.0 * u * u'),
+        )
+        alg = TransformedMCMC(
+            proposal = MALAProposal(),
+            adaptive_transform = LowRankAffineTransform(
+                init = BAT.UnitTransformInit(),
+                cutoff = 1.5,
+                max_rank = 1,
+            ),
+            pretransform = DoNotTransform(),
+            nchains = 1,
+            nwalkers = 1,
+            convergence = AssumeConvergence(),
+            nonzero_weights = false,
+        )
+
+        function run_decision(loss_sign, offdiag_sign, seed)
+            initial = [rand(StableRNG(seed), objective)]
+            state = BAT.MCMCState(
+                alg,
+                batmeasure(objective),
+                1,
+                initial,
+                BATContext(
+                    rng = Philox4x((seed + 1, seed + 2)),
+                    ad = ForwardDiff,
+                ),
+            )
+            BAT.mcmc_tuning_init!!(state, 1000)
+            BAT.next_cycle!(state)
+            BAT.mcmc_tuning_reinit!!(state, 1000)
+            campaign = state.trafo_tuner_state.campaign
+            @test campaign.fit_start == 201
+            @test campaign.guard_steps == 64
+            @test campaign.validation_steps == 512
+
+            fit_end = campaign.fit_start + campaign.fit_steps - 1
+            decision = fit_end + campaign.guard_steps + campaign.validation_steps
+            provisional_f = nothing
+            for step in 1:(decision - 1)
+                f_before = state.chain_state.f_transform
+                state = BAT.mcmc_step!!(state)
+                if step == fit_end
+                    @test !isnothing(campaign.candidate)
+                    @test state.chain_state.f_transform !== f_before
+                    provisional_f = state.chain_state.f_transform
+                end
+            end
+            campaign.validation_loss .= loss_sign .* reshape(
+                1e6 .+ 0.1 .* (-1.0) .^ (1:campaign.validation_steps),
+                1,
+                :,
+            )
+            if hasproperty(campaign, :validation_offdiag_loss)
+                campaign.validation_offdiag_loss .= offdiag_sign .* reshape(
+                    1e6 .+ 0.1 .* (-1.0) .^ (1:campaign.validation_steps),
+                    1,
+                    :,
+                )
+            end
+            state = BAT.mcmc_step!!(state)
+            return state, provisional_f
+        end
+
+        kept, provisional_f = run_decision(1.0, 1.0, 826_494_001)
+        @test kept.trafo_tuner_state.campaign.admitted
+        @test kept.chain_state.f_transform === provisional_f
+        @test kept.proposal_tuner_state.min_run_nobs == 40
+
+        rolled_back, provisional_f = run_decision(-1.0, 1.0, 826_494_002)
+        @test !rolled_back.trafo_tuner_state.campaign.admitted
+        @test rolled_back.chain_state.f_transform !== provisional_f
+        G_rollback = Matrix(
+            rolled_back.chain_state.f_transform.A *
+            rolled_back.chain_state.f_transform.A',
+        )
+        @test G_rollback ≈ Diagonal(diag(G_rollback))
+        @test rolled_back.proposal_tuner_state.min_run_nobs == 40
+
+        offdiag_rejected, _ = run_decision(1.0, -1.0, 826_494_003)
+        @test !offdiag_rejected.trafo_tuner_state.campaign.admitted
+    end
+
+    @testset "low-rank campaign lifecycle" begin
+        objective = product_distribution(fill(TDist(3), 16))
+        alg = TransformedMCMC(
+            proposal = MALAProposal(),
+            adaptive_transform = LowRankAffineTransform(),
+            pretransform = DoNotTransform(),
+            nchains = 1,
+            nwalkers = 1,
+            nsteps = 20,
+            init = MCMCChainPoolInit(nsteps_init = 10),
+            burnin = MCMCMultiCycleBurnin(
+                nsteps_per_cycle = 1000,
+                max_ncycles = 1,
+                nsteps_final = 0,
+            ),
+            convergence = AssumeConvergence(),
+        )
+        state = BAT.MCMCState(
+            alg,
+            batmeasure(objective),
+            1,
+            [zeros(16)],
+            BATContext(rng = Philox4x((42, 43)), ad = ForwardDiff),
+        )
+        BAT.mcmc_tuning_init!!(state, 1000)
+        BAT.next_cycle!(state)
+        BAT.mcmc_tuning_reinit!!(state, 1000)
+        for _ in 1:1000
+            state = BAT.mcmc_step!!(state)
+        end
+        campaign = state.trafo_tuner_state.campaign
+        @test campaign.phase == BAT._LRFrozen
+        @test campaign.attempted
+        @test !BAT.transform_tuning_pauses_proposal(state.trafo_tuner_state)
     end
 end


### PR DESCRIPTION
Follow-up to #564.

The rolling low-rank Fisher update can mistake noise for correlation on non-Gaussian targets and keep changing the geometry until tuning fails. This keeps low-rank learning, but limits it to one attempt and checks the result on held-out samples.

The correction is retained only when its off-diagonal part improves the fit. For HMC, it is applied after that check. For MALA, it is applied while the step size is tuned, then reverted if the check fails.

Invalid fits fall back safely, and short burn-in cycles can try again later. The change adds null, correlated-target, lifecycle, and end-to-end tests.

The full headless suite passes 21,698 tests.