### PR TITLE
Fix explicit measure transforms and standard deviation

### DIFF
--- a/src/algotypes/transform_algorithm.jl
+++ b/src/algotypes/transform_algorithm.jl
@@ -134,6 +134,10 @@ Constructors:
 """
 struct FullMeasureTransform <: TransformAlgorithm end
 
+function bat_transform_impl(f::Function, m::BATMeasure, ::FullMeasureTransform, ::BATContext)
+    (result = pushfwd(f, m, KeepRootMeasure()), f_transform = f)
+end
+
 
 _get_deep_prior_for_trafo(m::BATDistMeasure) = m
 _get_deep_prior_for_trafo(m::AbstractPosteriorMeasure) = _get_deep_prior_for_trafo(getprior(m))

--- a/src/measures/bat_dist_measure.jl
+++ b/src/measures/bat_dist_measure.jl
@@ -82,6 +82,7 @@ Base.@deprecate rand(rng::AbstractRNG, m::BATDistMeasure, dim::Integer, dims::In
 Statistics.mean(m::BATDistMeasure{<:Distribution}) = mean(m.dist)
 Statistics.median(m::BATDistMeasure{<:UnivariateDistribution}) = median(m.dist)
 Statistics.var(m::BATDistMeasure{<:Distribution}) = var(m.dist)
+Statistics.std(m::BATDistMeasure{<:Distribution}) = std(m.dist)
 Statistics.cov(m::BATDistMeasure{<:MultivariateDistribution}) = cov(m.dist)
 StatsBase.mode(m::BATDistMeasure{<:Distribution}) = mode(m.dist)
 

--- a/test/measures/test_bispaced_measure.jl
+++ b/test/measures/test_bispaced_measure.jl
@@ -17,6 +17,10 @@ using BAT: BispacedMeasure, batmeasure, empiricalof, samplesof
     dsm = DensitySampleMeasure(smpls, dof = getdof(m))
 
     f = BAT.transform_function(NormalBased(), m)
+    measure_pair = BispacedMeasure(f, m, context)
+    x = (a = 2.0, b = 0.7)
+    @test logdensityof(measure_pair.transformed, f(x)) ≈ logpdf(Normal(), 0.0) + logpdf(Normal(), quantile(Normal(), 1 - exp(-1)))
+
     p = BispacedMeasure(f, dsm, context)
     @test samplesof(p) == smpls
     @test empiricalof(p) === dsm

--- a/test/measures/test_evaluated_measure.jl
+++ b/test/measures/test_evaluated_measure.jl
@@ -6,6 +6,7 @@ using Test
 using Random
 using DensityInterface, MeasureBase, ValueShapes
 using Distributions
+using Statistics
 
 @testset "evaluated_measure" begin
     dist = distprod(a = truncated(Normal(), -2, 2), b = Exponential())
@@ -31,4 +32,5 @@ using Distributions
 
     em_plain = EvaluatedMeasure(m)
     @test BAT.empiricalof(em_plain) === nothing
+    @test std(EvaluatedMeasure(Normal(0, 2))) == 2
 end


### PR DESCRIPTION
Repairs two measure API failures in the code merged through #564.

- Restore explicit-function `bat_transform` for measures through the existing pushforward implementation.
- Forward `std` for distribution-backed measures, including `EvaluatedMeasure` without samples.
