### PR TITLE
Fix zero-mass quantiles and low-ESS bridge uncertainty

### DIFF
--- a/src/integration/bridge_sampling_integration.jl
+++ b/src/integration/bridge_sampling_integration.jl
@@ -176,7 +176,8 @@ function bridge_sampling_integral(
 
     proposal_measure = batmeasure(MvNormal(post_mean,post_cov_pd))
     held_out_ess = bat_eff_sample_size_impl(second_batch, KishESS(), context).result
-    n_proposal = clamp(round(Int, held_out_ess), 1, length(second_batch))
+    # The corrected proposal variance needs at least two independent draws.
+    n_proposal = max(2, min(round(Int, held_out_ess), length(second_batch)))
     proposal_samples = samplesof(evalmeasure(
         proposal_measure, IIDSampling(nsamples = n_proposal), context,
     ))

--- a/src/variates/density_sample.jl
+++ b/src/variates/density_sample.jl
@@ -360,7 +360,7 @@ function _weighted_empirical_quantile(v::AbstractVector, w::AbstractVector, p::R
     isempty(v) && throw(ArgumentError("quantile of an empty array is undefined"))
     0 <= p <= 1 || throw(ArgumentError("input probability out of [0,1] range"))
 
-    nan_idx = findfirst(isnan, v)
+    nan_idx = findfirst(i -> !iszero(w[i]) && isnan(v[i]), eachindex(v, w))
     isnothing(nan_idx) || return v[nan_idx]
 
     order = sortperm(v)

--- a/test/integration/test_bridge_sampling_integration.jl
+++ b/test/integration/test_bridge_sampling_integration.jl
@@ -42,6 +42,20 @@ import Measurements
         @test isfinite(Measurements.value(log(result)))
     end
 
+    @testset "concentrated held-out weights" begin
+        dist = MvNormal(zeros(1), ones(1))
+        values = [[x] for x in repeat(range(-1, 1, length = 10), 2)]
+        samples = DensitySampleVector(
+            v = values, logd = logpdf.(Ref(dist), values),
+            weight = [ones(10); 1000; ones(9)],
+        )
+        result = bat_integrate(
+            EvaluatedMeasure(dist, empirical = samples),
+            BridgeSampling(pretransform = DoNotTransform()), context,
+        ).result
+        @test isfinite(Measurements.uncertainty(log(result)))
+    end
+
     test_integration(BridgeSampling(pretransform=DoNotTransform()), "funnel distribution", FunnelDistribution(), val_rtol = 15)
     #! ToDo: Fix this test, cause trouble on x86-32
     #test_integration(BridgeSampling(pretransform=DoNotTransform()), "multimodal student-t distribution", MultimodalStudentT(), val_rtol = 50)

--- a/test/variates/test_density_sample.jl
+++ b/test/variates/test_density_sample.jl
@@ -148,6 +148,9 @@ _SampleAux() = _SampleInfo(0)
             )
             @test quantile(samples16, 0.25) == 1.0
 
+            zero_mass_nan = DensitySampleVector(v = [1.0, NaN], logd = zeros(2), weight = [1, 0])
+            @test quantile.(Ref(zero_mass_nan), probabilities) == ones(5)
+
             @test quantile.(Ref(compressed), probabilities) == quantile.(Ref(expanded), probabilities) == expected
         end
 


### PR DESCRIPTION
Repairs two weighted-sample failures found while auditing the code merged through #564.

- Ignore zero-mass NaNs when computing empirical quantiles.
- Draw at least two independent bridge proposal samples so the corrected variance has a defined denominator.
