### PR TITLE
Fix Fisher geometry and composite MCMC adaptation

### DIFF
--- a/benchmark/hmc_geometry_benchmark.jl
+++ b/benchmark/hmc_geometry_benchmark.jl
@@ -6,9 +6,10 @@
 #     julia --project=<env-with-BAT> benchmark/hmc_geometry_benchmark.jl
 #
 # Metrics per (target, tuner) cell: moment errors of the samples, total
-# divergent trajectories, total leapfrog steps (gradient evaluations),
-# effective sample size per 1000 gradient evaluations, final step sizes
-# and wall time.
+# divergent trajectories, total leapfrog steps, effective sample size per
+# 1000 leapfrog steps, and cold wall time. Leapfrog counts exclude initial
+# gradients and step-size searches. Cold timings include compilation and
+# are not suitable for comparing tuner speed.
 
 using BAT
 using LinearAlgebra, Random, Statistics, StatsBase, Printf
@@ -71,7 +72,7 @@ function run_cell(target, tuner_cfg; nsteps = 10^4)
         TransformedMCMC(proposal = HamiltonianMC(), pretransform = DoNotTransform(), adaptive_transform = at, transform_tuning = tt, nsteps = nsteps, strict = false)
     t0 = time()
     em = evalmeasure(target.measure, alg, deepcopy(context))
-    walltime = time() - t0
+    cold_walltime = time() - t0
 
     smpls = BAT.samplesof(em)
     diags = BAT.evalinfo(em).result.chain_diagnostics
@@ -94,9 +95,9 @@ function run_cell(target, tuner_cfg; nsteps = 10^4)
     (
         moment_err = moment_err,
         n_divergent = n_div,
-        ess_per_kgrad = 1000 * ess / n_leapfrog,
+        ess_per_kleapfrog = 1000 * ess / n_leapfrog,
         n_leapfrog = n_leapfrog,
-        walltime = walltime,
+        cold_walltime = cold_walltime,
     )
 end
 
@@ -112,8 +113,8 @@ for (tname, target) in targets, (aname, cfg) in tuners
     results[(tname, aname)] = r
     if !isnothing(r)
         @printf(
-            "%-22s %-15s momerr %-8.3f div %-6d ess/kgrad %-8.1f leapfrog %-10d t %6.1fs\n",
-            tname, aname, r.moment_err, r.n_divergent, r.ess_per_kgrad, r.n_leapfrog, r.walltime
+            "%-22s %-15s momerr %-8.3f div %-6d ess/kleapfrog %-8.1f leapfrog %-10d cold %6.1fs\n",
+            tname, aname, r.moment_err, r.n_divergent, r.ess_per_kleapfrog, r.n_leapfrog, r.cold_walltime
         )
     end
 end

--- a/src/samplers/mcmc/mcmc_tuning/mcmc_fisher_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_fisher_tuner.jl
@@ -553,12 +553,15 @@ _fisher_geometry(::LowRankFisherEstimator, acc::_XGMoments, γ::Real) =
 # Unique SPD solution G of the Riccati equation G C_g G = C_x, i.e. the
 # affine-invariant geometric mean of C_x and C_g⁻¹:
 function _spd_riccati_solve(C_x::Symmetric, C_g::Symmetric)
-    E = eigen(C_g)
+    # Normalize before multiplying, so tiny or large covariance scales do
+    # not underflow or overflow in the intermediate matrix product.
+    scale_x, scale_g = maximum(abs, C_x), maximum(abs, C_g)
+    E = eigen(C_g / scale_g)
     S_sqrt = E.vectors * Diagonal(sqrt.(E.values)) * E.vectors'
     S_isqrt = E.vectors * Diagonal(inv.(sqrt.(E.values))) * E.vectors'
-    F = eigen(Symmetric(S_sqrt * C_x * S_sqrt))
+    F = eigen(Symmetric(S_sqrt * (C_x / scale_x) * S_sqrt))
     M_sqrt = F.vectors * Diagonal(sqrt.(max.(F.values, 0))) * F.vectors'
-    return Symmetric(S_isqrt * M_sqrt * S_isqrt)
+    return Symmetric((sqrt(scale_x) / sqrt(scale_g)) * (S_isqrt * M_sqrt * S_isqrt))
 end
 
 # Fit one projected low-rank correction from an immutable block. The

--- a/src/samplers/mcmc/mcmc_tuning/mcmc_fisher_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_fisher_tuner.jl
@@ -276,13 +276,11 @@ function _lag1_update!(l1::_Lag1Stats, x::AbstractVector{<:Real})
     l1.ptr = ptr
     if l1.filled >= l1.stride
         l1.n1 += 1
-        # Each endpoint has its own mean over the observed lag pairs.
-        for i in eachindex(x)
-            dx = x[i] - l1.mean_x[i]
-            l1.mean_x[i] += dx / l1.n1
-            l1.mean_prev[i] += (l1.prev[i, ptr] - l1.mean_prev[i]) / l1.n1
-            l1.cross1[i] += dx * (l1.prev[i, ptr] - l1.mean_prev[i])
-        end
+        prev = view(l1.prev, :, ptr)
+        # The covariance uses the old x mean and the updated previous mean.
+        l1.mean_prev .+= (prev .- l1.mean_prev) ./ l1.n1
+        l1.cross1 .+= (x .- l1.mean_x) .* (prev .- l1.mean_prev)
+        l1.mean_x .+= (x .- l1.mean_x) ./ l1.n1
     else
         l1.filled += 1
     end

--- a/src/samplers/mcmc/mcmc_tuning/mcmc_fisher_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_fisher_tuner.jl
@@ -259,11 +259,14 @@ mutable struct _Lag1Stats{T<:AbstractFloat}
     ptr::Int
     prev::Matrix{T}
     cross1::Vector{T}
+    mean_x::Vector{T}
+    mean_prev::Vector{T}
 end
 
 function _Lag1Stats(::Type{T}, n_dims::Integer, stride::Integer) where {T<:AbstractFloat}
     stride = max(stride, 1)
-    _Lag1Stats(stride, 0, 0, 0, zeros(T, n_dims, stride), zeros(T, n_dims))
+    _Lag1Stats(stride, 0, 0, 0, zeros(T, n_dims, stride),
+        zeros(T, n_dims), zeros(T, n_dims), zeros(T, n_dims))
 end
 
 _Lag1Stats(n_dims::Integer, stride::Integer) = _Lag1Stats(Float64, n_dims, stride)
@@ -272,8 +275,14 @@ function _lag1_update!(l1::_Lag1Stats, x::AbstractVector{<:Real})
     ptr = mod1(l1.ptr + 1, l1.stride)
     l1.ptr = ptr
     if l1.filled >= l1.stride
-        l1.cross1 .+= x .* view(l1.prev, :, ptr)
         l1.n1 += 1
+        # Each endpoint has its own mean over the observed lag pairs.
+        for i in eachindex(x)
+            dx = x[i] - l1.mean_x[i]
+            l1.mean_x[i] += dx / l1.n1
+            l1.mean_prev[i] += (l1.prev[i, ptr] - l1.mean_prev[i]) / l1.n1
+            l1.cross1[i] += dx * (l1.prev[i, ptr] - l1.mean_prev[i])
+        end
     else
         l1.filled += 1
     end
@@ -347,7 +356,7 @@ function _effective_nobs(acc::_AbstractXGMoments)
     T = eltype(acc.mean_x)
     l1.n1 >= 10 || return T(acc.n)
     var_raw = _diag_var_raw(acc)
-    c1 = l1.cross1 ./ l1.n1 .- acc.mean_x .^ 2
+    c1 = l1.cross1 ./ l1.n1
     ρs = c1 ./ max.(var_raw, floatmin(T))
     ρ = clamp(sum(ρs) / length(ρs), zero(T), T(99) / 100)
     return acc.n * (1 - ρ) / (1 + ρ)

--- a/src/samplers/mcmc/mcmc_tuning/mcmc_multiproposal_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_multiproposal_tuner.jl
@@ -124,13 +124,32 @@ function mcmc_proposal_transform_committed!!(
 )
     proposals, tuners = multi_proposal.proposal_states, multi_tuner.proposal_tuners
     for i in eachindex(proposals)
-        component_chain = @set chain_state.proposal = proposals[i]
-        proposals[i], tuners[i], component_chain = mcmc_proposal_transform_committed!!(
-            proposals[i], tuners[i], component_chain, trafo_tuners...,
+        chain_state = _component_transform_committed!!(
+            proposals[i], tuners[i], multi_proposal, multi_tuner, chain_state, i, trafo_tuners...,
         )
-        chain_state = @set component_chain.proposal = multi_proposal
     end
     return multi_proposal, multi_tuner, chain_state
+end
+
+
+# Specialize the chain reconstruction and callback after dispatching on the
+# concrete component types stored in the heterogeneous proposal/tuner vectors.
+function _component_transform_committed!!(
+    proposal::MCMCProposalState,
+    tuner::MCMCProposalTunerState,
+    multi_proposal::MultiProposalState,
+    multi_tuner::MultiProposalTunerState,
+    chain_state::MCMCChainState,
+    i::Integer,
+    trafo_tuners::Vararg{MCMCTransformTunerState,N},
+) where {N}
+    component_chain = @set chain_state.proposal = proposal
+    proposal, tuner, component_chain = mcmc_proposal_transform_committed!!(
+        proposal, tuner, component_chain, trafo_tuners...,
+    )
+    multi_proposal.proposal_states[i] = proposal
+    multi_tuner.proposal_tuners[i] = tuner
+    return @set component_chain.proposal = multi_proposal
 end
 
 

--- a/src/samplers/mcmc/mcmc_tuning/mcmc_multiproposal_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_multiproposal_tuner.jl
@@ -98,8 +98,9 @@ function mcmc_proposal_tuning_init!!(
     chain_state::MCMCChainState, 
     max_nsteps::Integer
 )
-    for tuner in multi_tuner_state.proposal_tuners
-        mcmc_proposal_tuning_init!!(tuner, chain_state, max_nsteps)
+    for i in eachindex(multi_tuner_state.proposal_tuners)
+        component_chain = @set chain_state.proposal = chain_state.proposal.proposal_states[i]
+        mcmc_proposal_tuning_init!!(multi_tuner_state.proposal_tuners[i], component_chain, max_nsteps)
     end
 end
 
@@ -108,8 +109,9 @@ function mcmc_proposal_tuning_reinit!!(
     chain_state::MCMCChainState,
     max_nsteps::Integer
 )
-    for tuner in multi_tuner_state.proposal_tuners
-        mcmc_proposal_tuning_reinit!!(tuner, chain_state, max_nsteps)
+    for i in eachindex(multi_tuner_state.proposal_tuners)
+        component_chain = @set chain_state.proposal = chain_state.proposal.proposal_states[i]
+        mcmc_proposal_tuning_reinit!!(multi_tuner_state.proposal_tuners[i], component_chain, max_nsteps)
     end
 end
 

--- a/src/samplers/mcmc/mcmc_tuning/mcmc_multiproposal_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_multiproposal_tuner.jl
@@ -116,6 +116,24 @@ function mcmc_proposal_tuning_reinit!!(
 end
 
 
+function mcmc_proposal_transform_committed!!(
+    multi_proposal::MultiProposalState,
+    multi_tuner::MultiProposalTunerState,
+    chain_state::MCMCChainState,
+    trafo_tuners::Vararg{MCMCTransformTunerState},
+)
+    proposals, tuners = multi_proposal.proposal_states, multi_tuner.proposal_tuners
+    for i in eachindex(proposals)
+        component_chain = @set chain_state.proposal = proposals[i]
+        proposals[i], tuners[i], component_chain = mcmc_proposal_transform_committed!!(
+            proposals[i], tuners[i], component_chain, trafo_tuners...,
+        )
+        chain_state = @set component_chain.proposal = multi_proposal
+    end
+    return multi_proposal, multi_tuner, chain_state
+end
+
+
 function mcmc_proposal_tuning_postinit!!(
     multi_tuner::MultiProposalTunerState, 
     chain_state::MCMCChainState, 

--- a/src/samplers/mcmc/mcmc_tuning/mcmc_stanlike_tuner.jl
+++ b/src/samplers/mcmc/mcmc_tuning/mcmc_stanlike_tuner.jl
@@ -40,6 +40,9 @@ mutable struct StanLikeTunerState{S<:MCMCBasicStats} <: MCMCTransformTunerState
 end
 
 function create_trafo_tuner_state(tuning::StanLikeTuning, chain_state::MCMCChainState, n_steps_hint::Integer)
+    @argcheck tuning.init_buffer >= 0
+    @argcheck tuning.term_buffer >= 0
+    @argcheck tuning.window_size > 0
     chain_state.f_transform isa MulAdd || throw(ArgumentError(
         "StanLikeTuning requires an affine adaptive space transformation (like TriangularAffineTransform)"
     ))

--- a/test/samplers/mcmc/test_fisher_tuner.jl
+++ b/test/samplers/mcmc/test_fisher_tuner.jl
@@ -4,6 +4,7 @@ using BAT
 using Test
 
 using LinearAlgebra, Random
+using Statistics
 using StableRNGs
 
 using BAT: DenseFisherEstimator, LowRankFisherEstimator,
@@ -11,6 +12,20 @@ using BAT: DenseFisherEstimator, LowRankFisherEstimator,
 
 @testset "fisher_tuner" begin
     rng = StableRNG(438621057)
+
+    @testset "lag estimate preserves translation and walker pairing" begin
+        values = [0, 0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 6, -5]
+        earlier, later = values[1:end-2], values[3:end]
+        rho = mean((earlier .- mean(earlier)) .* (later .- mean(later))) / var(values)
+        expected = length(values) * (1 - rho) / (1 + rho)
+        for shift in (0.0, 100.0)
+            moments = _new_moments(DenseFisherEstimator(), 1, 2)
+            for x in values
+                _moments_update!(moments, [x + shift], [-Float64(x)])
+            end
+            @test BAT._effective_nobs(moments) ≈ expected
+        end
+    end
 
     @testset "Gaussian geometry recovery" begin
         d = 4

--- a/test/samplers/mcmc/test_fisher_tuner.jl
+++ b/test/samplers/mcmc/test_fisher_tuner.jl
@@ -27,6 +27,16 @@ using BAT: DenseFisherEstimator, LowRankFisherEstimator,
         end
     end
 
+    @testset "equal tiny covariance scales" begin
+        moments = _new_moments(DenseFisherEstimator(), 2)
+        for _ in 1:20
+            _moments_update!(moments, [1.0, 2.0], [-1.0, -2.0])
+        end
+        geometry, location = _fisher_geometry(DenseFisherEstimator(), moments, 1e-5)
+        @test geometry ≈ I
+        @test location ≈ zeros(2) atol = 1e-14
+    end
+
     @testset "Gaussian geometry recovery" begin
         d = 4
         A = LowerTriangular(Matrix(I(d)) + 0.4 * randn(rng, d, d))

--- a/test/samplers/mcmc/test_hmc.jl
+++ b/test/samplers/mcmc/test_hmc.jl
@@ -36,6 +36,7 @@ import ForwardDiff, Zygote
         )
         dist = batmeasure(MvNormal(zeros(2), [1.0 0.5; 0.5 3.0]))
         state = BAT.MCMCState(alg, dist, 1, [[0.2, -0.2]], deepcopy(context))
+        @test_throws ArgumentError BAT.create_trafo_tuner_state(BAT.StanLikeTuning(window_size = 0), state.chain_state, 100)
         for initialize in (BAT.mcmc_tuning_init!!, BAT.mcmc_tuning_reinit!!)
             initialize(state, 100)
             centers = [t.log_mu for t in state.proposal_tuner_state.proposal_tuners]

--- a/test/samplers/mcmc/test_hmc.jl
+++ b/test/samplers/mcmc/test_hmc.jl
@@ -23,6 +23,26 @@ import ForwardDiff, Zygote
     nwalkers = 1
     samplingalg = TransformedMCMC(proposal = proposal, transform_tuning = transform_tuning, nchains = nchains, nwalkers = nwalkers)
 
+    @testset "composite step-size adaptation" begin
+        alg = TransformedMCMC(
+            proposal = MCMCMultiProposal(
+                proposals = BAT.MCMCProposal[HamiltonianMC(step_size = 0.1), HamiltonianMC(step_size = 1.0)],
+                picking_rule = [1, 1],
+            ),
+            pretransform = DoNotTransform(),
+            adaptive_transform = BAT.TriangularAffineTransform(init = BAT.UnitTransformInit()),
+            transform_tuning = BAT.StanLikeTuning(init_buffer = 0, term_buffer = 10, window_size = 25),
+            nchains = 1, convergence = AssumeConvergence(),
+        )
+        dist = batmeasure(MvNormal(zeros(2), [1.0 0.5; 0.5 3.0]))
+        state = BAT.MCMCState(alg, dist, 1, [[0.2, -0.2]], deepcopy(context))
+        for initialize in (BAT.mcmc_tuning_init!!, BAT.mcmc_tuning_reinit!!)
+            initialize(state, 100)
+            centers = [t.log_mu for t in state.proposal_tuner_state.proposal_tuners]
+            @test centers ≈ [0.0, log(10.0)]
+        end
+    end
+
     @testset "MCMC iteration" begin
         context = BATContext(rng = Philox4x((564, 47)), ad = ForwardDiff)
         nsteps = 10^4

--- a/test/samplers/mcmc/test_hmc.jl
+++ b/test/samplers/mcmc/test_hmc.jl
@@ -42,6 +42,12 @@ import ForwardDiff, Zygote
             centers = [t.log_mu for t in state.proposal_tuner_state.proposal_tuners]
             @test centers ≈ [0.0, log(10.0)]
         end
+        initial_transform = state.chain_state.f_transform
+        for _ in 1:25
+            state = BAT.mcmc_step!!(state)
+        end
+        @test state.chain_state.f_transform !== initial_transform
+        @test all(t -> t.m == 0 && t.run_nobs == 0, state.proposal_tuner_state.proposal_tuners)
     end
 
     @testset "MCMC iteration" begin


### PR DESCRIPTION
Repairs the Fisher and adaptive-MCMC failures found in the code merged through #564.

- Center lag covariance over its own endpoint pairs, preserving translation invariance and same-walker ordering.
- Normalize dense Riccati inputs before matrix products to avoid covariance-scale underflow.
- Initialize each composite proposal tuner with its own scale.
- Restart every composite tuner after geometry changes, through both post-step and post-cycle callbacks.
- Reject invalid Stan adaptation window lengths before schedule construction.
- Label benchmark work as leapfrog steps and timings as cold timings, not gradient counts or comparable steady-state speed.
